### PR TITLE
[ENH] Implemented `ColumnAnnotationCard` component

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -1,0 +1,22 @@
+{
+  "standardizedVariables": {
+    "Subject ID": {
+      "identifier": "nb:ParticipantID"
+    },
+    "Session ID": {
+      "identifier": "nb:SessionID"
+    },
+    "Age": {
+      "identifier": "nb:Age"
+    },
+    "Sex": {
+      "identifier": "nb:Sex"
+    },
+    "Diagnosis": {
+      "identifier": "nb:Diagnosis"
+    },
+    "Assessment Tool": {
+      "identifier": "nb:AssessmentTool"
+    }
+  }
+}

--- a/configs/default.json
+++ b/configs/default.json
@@ -1,22 +1,28 @@
 {
   "standardizedVariables": {
     "Subject ID": {
-      "identifier": "nb:ParticipantID"
+      "identifier": "nb:ParticipantID",
+      "label": "Participant ID"
     },
     "Session ID": {
-      "identifier": "nb:SessionID"
+      "identifier": "nb:SessionID",
+      "label": "Session ID"
     },
     "Age": {
-      "identifier": "nb:Age"
+      "identifier": "nb:Age",
+      "label": "Age"
     },
     "Sex": {
-      "identifier": "nb:Sex"
+      "identifier": "nb:Sex",
+      "label": "Sex"
     },
     "Diagnosis": {
-      "identifier": "nb:Diagnosis"
+      "identifier": "nb:Diagnosis",
+      "label": "Diagnosis"
     },
     "Assessment Tool": {
-      "identifier": "nb:AssessmentTool"
+      "identifier": "nb:AssessmentTool",
+      "label": "Assessment Tool"
     }
   }
 }

--- a/cypress/component/ColumAnnotation.cy.tsx
+++ b/cypress/component/ColumAnnotation.cy.tsx
@@ -1,11 +1,69 @@
 import ColumnAnnotation from '../../src/components/ColumnAnnotation';
+import useDataStore from '../../src/stores/data';
 
 describe('ColumnAnnotation', () => {
-  it('should render correctly', () => {
+  beforeEach(() => {
+    useDataStore.setState({
+      columns: {
+        1: {
+          header: 'some column',
+          description: 'This is some column',
+          dataType: 'Categorical',
+          standardizedVariable: { identifier: 'somevar', label: 'some variable' },
+        },
+        2: {
+          header: 'another column',
+          description: 'This is another column',
+          dataType: 'Continuous',
+          standardizedVariable: null,
+        },
+      },
+      standardizedVaribles: {
+        var1: {
+          identifier: 'somevar',
+          label: 'some variable',
+        },
+        var2: {
+          identifier: 'anothervar',
+          label: 'another variable',
+        },
+      },
+    });
+  });
+
+  it('renders the component correctly', () => {
     cy.mount(<ColumnAnnotation />);
     cy.contains('Column Annotation');
+    cy.get('[data-cy="1-column-annotation-card"]').should('be.visible');
+    cy.get('[data-cy="1-description"]').should('be.visible').and('contain', 'This is some column');
+    cy.get('[data-cy="1-column-annotation-card-standardized-variable-dropdown"] input')
+      .should('be.visible')
+      .and('have.value', 'some variable');
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]')
+      .should('be.visible')
+      .and('have.class', 'Mui-selected');
+    cy.get('[data-cy="2-column-annotation-card"]').should('be.visible');
+    cy.get('[data-cy="2-description"]')
+      .should('be.visible')
+      .and('contain', 'This is another column');
+    cy.get('[data-cy="2-column-annotation-card-standardized-variable-dropdown"] input')
+      .should('be.visible')
+      .and('have.value', '');
+    cy.get('[data-cy="2-column-annotation-card-data-type-continuous-button"]')
+      .should('be.visible')
+      .and('have.class', 'Mui-selected');
   });
-  it.only('toggles the data type between categorical and continuous', () => {
+  it('edits the description', () => {
+    cy.mount(<ColumnAnnotation />);
+    cy.get('[data-cy="1-edit-description-button"]').click();
+    cy.get('[data-cy="1-description-input"]').clear();
+    cy.get('[data-cy="1-description-input"]').type('new description');
+    cy.get('[data-cy="1-save-description-button"]').click();
+    cy.get('[data-cy="1-description"]').should('contain', 'new description');
+  });
+  it('toggles the data type between categorical and continuous', () => {
+    cy.mount(<ColumnAnnotation />);
+
     cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
       'have.class',
       'Mui-selected'
@@ -14,7 +72,9 @@ describe('ColumnAnnotation', () => {
       'not.have.class',
       'Mui-selected'
     );
+
     cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').click();
+
     cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
       'have.class',
       'Mui-selected'

--- a/cypress/component/ColumAnnotation.cy.tsx
+++ b/cypress/component/ColumAnnotation.cy.tsx
@@ -5,4 +5,23 @@ describe('ColumnAnnotation', () => {
     cy.mount(<ColumnAnnotation />);
     cy.contains('Column Annotation');
   });
+  it.only('toggles the data type between categorical and continuous', () => {
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
+      'have.class',
+      'Mui-selected'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
+      'not.have.class',
+      'Mui-selected'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').click();
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
+      'have.class',
+      'Mui-selected'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
+      'not.have.class',
+      'Mui-selected'
+    );
+  });
 });

--- a/cypress/component/ColumnAnnotationCard.cy.tsx
+++ b/cypress/component/ColumnAnnotationCard.cy.tsx
@@ -1,0 +1,134 @@
+import ColumnAnnotationCard from '../../src/components/ColumnAnnotationCard';
+import { mockStandardizedVariables } from '../../src/utils/mocks';
+
+const props = {
+  id: 1,
+  header: 'some header',
+  description: 'some description',
+  dataType: 'Categorical' as 'Categorical' | 'Continuous' | null,
+  standardizedVariable: { identifier: 'participant_id' },
+  standardizedVariableOptions: mockStandardizedVariables,
+  onDescriptionChange: () => {},
+  onDataTypeChange: () => {},
+  onStandardizedVariableChange: () => {},
+};
+
+describe('ColumnAnnotationCard', () => {
+  beforeEach(() => {
+    cy.mount(
+      <ColumnAnnotationCard
+        id={props.id}
+        header={props.header}
+        description={props.description}
+        dataType={props.dataType}
+        standardizedVariable={props.standardizedVariable}
+        standardizedVariableOptions={props.standardizedVariableOptions}
+        onDescriptionChange={props.onDescriptionChange}
+        onDataTypeChange={props.onDataTypeChange}
+        onStandardizedVariableChange={props.onStandardizedVariableChange}
+      />
+    );
+  });
+  it('renders the component', () => {
+    cy.get('[data-cy="1-column-annotation-card"]')
+      .should('be.visible')
+      .and('contain', 'some header');
+    cy.get('[data-cy="1-column-annotation-card-description"]')
+      .should('be.visible')
+      .and('contain', 'some description');
+    cy.get('[data-cy="1-column-annotation-card-edit-description-button"]').should('be.visible');
+    cy.get('[data-cy="1-column-annotation-card-edit-description-button"]').click();
+    cy.get('[data-cy="1-column-annotation-card-description-input"]')
+      .should('be.visible')
+      .and('contain', 'some description');
+    cy.get('[data-cy="1-column-annotation-card-save-description-button"]').should('be.visible');
+    cy.get('[data-cy="1-column-annotation-card-data-type"]').should('be.visible');
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]')
+      .should('be.visible')
+      .and('contain', 'Categorical');
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]')
+      .should('be.visible')
+      .and('contain', 'Continuous');
+    cy.get('[data-cy="1-column-annotation-card-standardized-variable-dropdown"] input')
+      .should('be.visible')
+      .and('have.value', 'participant_id');
+  });
+  it('toggles the data type between categorical and continuous', () => {
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
+      'have.class',
+      'Mui-selected'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
+      'not.have.class',
+      'Mui-selected'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').click();
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
+      'have.class',
+      'Mui-selected'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
+      'not.have.class',
+      'Mui-selected'
+    );
+  });
+  it('Fires the onDescriptionChange event handler with the appropriate payload when the save button is clicked', () => {
+    const spy = cy.spy().as('spy');
+    cy.mount(
+      <ColumnAnnotationCard
+        id={props.id}
+        header={props.header}
+        description={props.description}
+        dataType={props.dataType}
+        standardizedVariable={props.standardizedVariable}
+        standardizedVariableOptions={props.standardizedVariableOptions}
+        onDescriptionChange={spy}
+        onDataTypeChange={props.onDataTypeChange}
+        onStandardizedVariableChange={props.onStandardizedVariableChange}
+      />
+    );
+    cy.get('[data-cy="1-column-annotation-card-edit-description-button"]').click();
+    cy.get('[data-cy="1-column-annotation-card-description-input"]').clear();
+    cy.get('[data-cy="1-column-annotation-card-description-input"]').type('new description');
+    cy.get('[data-cy="1-column-annotation-card-save-description-button"]').click();
+    cy.get('@spy').should('have.been.calledWith', 1, 'new description');
+  });
+  it('Fires the onDataTypeChange event handler with the appropriate payload when the data type is toggled', () => {
+    const spy = cy.spy().as('spy');
+    cy.mount(
+      <ColumnAnnotationCard
+        id={props.id}
+        header={props.header}
+        description={props.description}
+        dataType={props.dataType}
+        standardizedVariable={props.standardizedVariable}
+        standardizedVariableOptions={props.standardizedVariableOptions}
+        onDescriptionChange={props.onDescriptionChange}
+        onDataTypeChange={spy}
+        onStandardizedVariableChange={props.onStandardizedVariableChange}
+      />
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').click();
+    cy.get('@spy').should('have.been.calledWith', 1, 'Continuous');
+  });
+  it('Fires the onStandardizedVariableChange event handler with the appropriate payload when the standardized variable is changed', () => {
+    const spy = cy.spy().as('spy');
+    cy.mount(
+      <ColumnAnnotationCard
+        id={props.id}
+        header={props.header}
+        description={props.description}
+        dataType={props.dataType}
+        standardizedVariable={props.standardizedVariable}
+        standardizedVariableOptions={props.standardizedVariableOptions}
+        onDescriptionChange={props.onDescriptionChange}
+        onDataTypeChange={props.onDataTypeChange}
+        onStandardizedVariableChange={spy}
+      />
+    );
+    cy.get('[data-cy="1-column-annotation-card-standardized-variable-dropdown"]').type(
+      'age{downarrow}{enter}'
+    );
+    cy.get('@spy').should('have.been.calledWith', 1, { identifier: 'nb:Age' });
+  });
+});

--- a/cypress/component/ColumnAnnotationCard.cy.tsx
+++ b/cypress/component/ColumnAnnotationCard.cy.tsx
@@ -6,7 +6,7 @@ const props = {
   header: 'some header',
   description: 'some description',
   dataType: 'Categorical' as 'Categorical' | 'Continuous' | null,
-  standardizedVariable: { identifier: 'participant_id' },
+  standardizedVariable: { identifier: 'participant_id', label: 'Participant ID' },
   standardizedVariableOptions: mockStandardizedVariables,
   onDescriptionChange: () => {},
   onDataTypeChange: () => {},
@@ -33,15 +33,13 @@ describe('ColumnAnnotationCard', () => {
     cy.get('[data-cy="1-column-annotation-card"]')
       .should('be.visible')
       .and('contain', 'some header');
-    cy.get('[data-cy="1-column-annotation-card-description"]')
+    cy.get('[data-cy="1-description"]').should('be.visible').and('contain', 'some description');
+    cy.get('[data-cy="1-edit-description-button"]').should('be.visible');
+    cy.get('[data-cy="1-edit-description-button"]').click();
+    cy.get('[data-cy="1-description-input"]')
       .should('be.visible')
       .and('contain', 'some description');
-    cy.get('[data-cy="1-column-annotation-card-edit-description-button"]').should('be.visible');
-    cy.get('[data-cy="1-column-annotation-card-edit-description-button"]').click();
-    cy.get('[data-cy="1-column-annotation-card-description-input"]')
-      .should('be.visible')
-      .and('contain', 'some description');
-    cy.get('[data-cy="1-column-annotation-card-save-description-button"]').should('be.visible');
+    cy.get('[data-cy="1-save-description-button"]').should('be.visible');
     cy.get('[data-cy="1-column-annotation-card-data-type"]').should('be.visible');
     cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]')
       .should('be.visible')
@@ -51,26 +49,7 @@ describe('ColumnAnnotationCard', () => {
       .and('contain', 'Continuous');
     cy.get('[data-cy="1-column-annotation-card-standardized-variable-dropdown"] input')
       .should('be.visible')
-      .and('have.value', 'participant_id');
-  });
-  it('toggles the data type between categorical and continuous', () => {
-    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
-      'have.class',
-      'Mui-selected'
-    );
-    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
-      'not.have.class',
-      'Mui-selected'
-    );
-    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').click();
-    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should(
-      'have.class',
-      'Mui-selected'
-    );
-    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
-      'not.have.class',
-      'Mui-selected'
-    );
+      .and('have.value', 'Participant ID');
   });
   it('Fires the onDescriptionChange event handler with the appropriate payload when the save button is clicked', () => {
     const spy = cy.spy().as('spy');
@@ -87,10 +66,10 @@ describe('ColumnAnnotationCard', () => {
         onStandardizedVariableChange={props.onStandardizedVariableChange}
       />
     );
-    cy.get('[data-cy="1-column-annotation-card-edit-description-button"]').click();
-    cy.get('[data-cy="1-column-annotation-card-description-input"]').clear();
-    cy.get('[data-cy="1-column-annotation-card-description-input"]').type('new description');
-    cy.get('[data-cy="1-column-annotation-card-save-description-button"]').click();
+    cy.get('[data-cy="1-edit-description-button"]').click();
+    cy.get('[data-cy="1-description-input"]').clear();
+    cy.get('[data-cy="1-description-input"]').type('new description');
+    cy.get('[data-cy="1-save-description-button"]').click();
     cy.get('@spy').should('have.been.calledWith', 1, 'new description');
   });
   it('Fires the onDataTypeChange event handler with the appropriate payload when the data type is toggled', () => {
@@ -129,6 +108,6 @@ describe('ColumnAnnotationCard', () => {
     cy.get('[data-cy="1-column-annotation-card-standardized-variable-dropdown"]').type(
       'age{downarrow}{enter}'
     );
-    cy.get('@spy').should('have.been.calledWith', 1, { identifier: 'nb:Age' });
+    cy.get('@spy').should('have.been.calledWith', 1, { identifier: 'nb:Age', label: 'Age' });
   });
 });

--- a/cypress/component/DescriptionEditor.cy.tsx
+++ b/cypress/component/DescriptionEditor.cy.tsx
@@ -1,0 +1,39 @@
+import DescriptionEditor from '../../src/components/DescriptionEditor';
+
+const props = {
+  description: 'Sample description',
+  onDescriptionChange: () => {},
+  id: 1,
+};
+
+describe('DescriptionEditor', () => {
+  it('renders the component correctly', () => {
+    cy.mount(
+      <DescriptionEditor
+        description={props.description}
+        onDescriptionChange={props.onDescriptionChange}
+        id={props.id}
+      />
+    );
+    cy.get('[data-cy="1-description"]').should('be.visible').and('contain', 'Sample description');
+    cy.get('[data-cy="1-edit-description-button"]').should('be.visible');
+    cy.get('[data-cy="1-edit-description-button"]').click();
+    cy.get('[data-cy="1-save-description-button"]').should('be.visible');
+    cy.get('[data-cy="1-description-input"]')
+      .should('be.visible')
+      .and('contain', 'Sample description');
+    cy.get('[data-cy="1-save-description-button"]').click();
+    cy.get('[data-cy="1-description-input"]').should('not.exist');
+  });
+  it('fires the onDescriptionChange event handler with the appropriate payload when the save button is clicked', () => {
+    const spy = cy.spy().as('spy');
+    cy.mount(
+      <DescriptionEditor description={props.description} onDescriptionChange={spy} id={props.id} />
+    );
+    cy.get('[data-cy="1-edit-description-button"]').click();
+    cy.get('[data-cy="1-description-input"]').clear();
+    cy.get('[data-cy="1-description-input"]').type('new description');
+    cy.get('[data-cy="1-save-description-button"]').click();
+    cy.get('@spy').should('have.been.calledWith', 1, 'new description');
+  });
+});

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -34,7 +34,7 @@ function ColumnAnnotation() {
 
   const handleDataTypeChange = (
     columnId: number,
-    newDataType: ['Categorical' | 'Continuous'] | null
+    newDataType: 'Categorical' | 'Continuous' | null
   ) => {
     updateColumnDataType(columnId, newDataType);
   };

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -1,9 +1,79 @@
+import React, { useState } from 'react';
+import Pagination from '@mui/material/Pagination';
+import { StandardizedVarible } from '~/utils/types';
 import NavigationButton from './NavigationButton';
+import ColumnAnnotationCard from './ColumnAnnotationCard';
+import useDataStore from '../stores/data';
 
 function ColumnAnnotation() {
+  const columns = useDataStore((state) => state.columns);
+  const standardizedVariableOptions = useDataStore((state) => state.standardizedVaribles);
+  const updateColumnDescription = useDataStore((state) => state.updateColumnDescription);
+  const updateColumnDataType = useDataStore((state) => state.updateColumnDataType);
+  const updateColumnStandardizedVariable = useDataStore(
+    (state) => state.updateColumnStandardizedVariable
+  );
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const columnsPerPage = 3;
+
+  const columnEntries = Object.entries(columns);
+  const indexOfLastColumn = currentPage * columnsPerPage;
+  const indexOfFirstColumn = indexOfLastColumn - columnsPerPage;
+  const currentColumns = columnEntries.slice(indexOfFirstColumn, indexOfLastColumn);
+
+  const totalPages = Math.ceil(columnEntries.length / columnsPerPage);
+
+  const handlePageChange = (_: React.ChangeEvent<unknown>, page: number) => {
+    setCurrentPage(page);
+  };
+
+  const handleDescriptionChange = (columnId: number, newDescription: string | null) => {
+    updateColumnDescription(columnId, newDescription);
+  };
+
+  const handleDataTypeChange = (
+    columnId: number,
+    newDataType: ['Categorical' | 'Continuous'] | null
+  ) => {
+    updateColumnDataType(columnId, newDataType);
+  };
+
+  const handleStandardizedVariableChange = (
+    columnId: number,
+    newStandardizedVariable: StandardizedVarible | null
+  ) => {
+    updateColumnStandardizedVariable(columnId, newStandardizedVariable);
+  };
+
   return (
     <div className="flex flex-col items-center">
       <h1>Column Annotation</h1>
+      {currentColumns.map(([columnId, column]) => (
+        <ColumnAnnotationCard
+          key={columnId}
+          id={parseInt(columnId, 10)}
+          header={column.header}
+          description={column.description || null}
+          dataType={column.dataType || null}
+          standardizedVariable={column.standardizedVariable || null}
+          standardizedVariableOptions={standardizedVariableOptions}
+          onDescriptionChange={handleDescriptionChange}
+          onDataTypeChange={handleDataTypeChange}
+          onStandardizedVariableChange={handleStandardizedVariableChange}
+        />
+      ))}
+
+      <div className="my-4">
+        <Pagination
+          count={totalPages}
+          page={currentPage}
+          onChange={handlePageChange}
+          color="primary"
+          shape="rounded"
+        />
+      </div>
+
       <div className="flex space-x-4">
         <NavigationButton label="Back - Upload" viewToNavigateTo="upload" />
         <NavigationButton label="Next - Value Annotation" viewToNavigateTo="valueAnnotation" />

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -24,7 +24,7 @@ function ColumnAnnotation() {
 
   const totalPages = Math.ceil(columnEntries.length / columnsPerPage);
 
-  const handlePageChange = (_: React.ChangeEvent<unknown>, page: number) => {
+  const handlePaginationChange = (_: React.ChangeEvent<unknown>, page: number) => {
     setCurrentPage(page);
   };
 
@@ -68,7 +68,7 @@ function ColumnAnnotation() {
         <Pagination
           count={totalPages}
           page={currentPage}
-          onChange={handlePageChange}
+          onChange={handlePaginationChange}
           color="primary"
           shape="rounded"
         />

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -97,6 +97,7 @@ function ColumnAnnotationCard({
               color="secondary"
               aria-label="save"
               onClick={handleSaveDescription}
+              size="small"
               className="mt-4 md:mt-0"
             >
               <SaveIcon />

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Typography,
+  TextField,
+  ToggleButtonGroup,
+  ToggleButton,
+  Fab,
+  Autocomplete,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import { StandardizedVarible, StandardizedVaribles } from '../utils/types';
+
+interface ColumnAnnotationCardProps {
+  id: number;
+  header: string;
+  description: string | null;
+  dataType: ['Categorical' | 'Continuous'] | null;
+  standardizedVariable: StandardizedVarible | null;
+  standardizedVariableOptions: StandardizedVaribles;
+  onDescriptionChange: (columnId: number, newDescription: string | null) => void;
+  onDataTypeChange: (columnId: number, newDataType: ['Categorical' | 'Continuous'] | null) => void;
+  onStandardizedVariableChange: (
+    columnId: number,
+    newStandardizedVariable: StandardizedVarible | null
+  ) => void;
+}
+
+function ColumnAnnotationCard({
+  id,
+  header,
+  description,
+  dataType,
+  standardizedVariable,
+  standardizedVariableOptions,
+  onDescriptionChange,
+  onDataTypeChange,
+  onStandardizedVariableChange,
+}: ColumnAnnotationCardProps) {
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [editedDescription, setEditedDescription] = useState<string | null>(description);
+  const [selectedDataType, setSelectedDataType] = useState<['Categorical' | 'Continuous'] | null>(
+    dataType
+  );
+  const [selectedStandardizedVariableKey, setSelectedStandardizedVariableKey] = useState<
+    string | null
+  >(standardizedVariable ? standardizedVariable.identifier : null);
+
+  // Handle description edit
+  const handleEditDescription = () => {
+    setIsEditingDescription(true);
+  };
+
+  // Handle description save
+  const handleSaveDescription = () => {
+    setIsEditingDescription(false);
+    onDescriptionChange(id, editedDescription);
+  };
+
+  // Handle data type change
+  const handleDataTypeChange = (
+    _: React.MouseEvent<HTMLElement>,
+    newDataType: ['Categorical' | 'Continuous'] | null
+  ) => {
+    setSelectedDataType(newDataType);
+    onDataTypeChange(id, newDataType);
+  };
+
+  // Handle standardized variable change
+  const handleStandardizedVariableChange = (
+    _: React.ChangeEvent<unknown>,
+    newValue: string | null
+  ) => {
+    setSelectedStandardizedVariableKey(newValue);
+    const newStandardizedVariable = newValue ? standardizedVariableOptions[newValue] : null;
+    onStandardizedVariableChange(id, newStandardizedVariable);
+  };
+
+  return (
+    <Card className="mx-auto w-full max-w-5xl shadow-lg">
+      <CardHeader title={header} className="bg-gray-50" />
+      <CardContent>
+        {isEditingDescription ? (
+          <div className="flex flex-col items-center gap-4 md:flex-row">
+            <TextField
+              fullWidth
+              multiline
+              rows={3}
+              value={editedDescription || ''}
+              onChange={(e) => setEditedDescription(e.target.value)}
+              variant="outlined"
+              label="Description"
+              className="flex-1"
+            />
+            <Fab
+              color="secondary"
+              aria-label="save"
+              onClick={handleSaveDescription}
+              className="mt-4 md:mt-0"
+            >
+              <SaveIcon />
+            </Fab>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4 md:flex-row">
+            <div className="flex-1">
+              <Typography variant="subtitle1" className="mb-2 text-gray-700">
+                Description:
+              </Typography>
+              <Typography variant="body1" className="text-gray-700">
+                {description || 'No description provided.'}
+              </Typography>
+            </div>
+            <Fab
+              color="primary"
+              aria-label="edit"
+              onClick={handleEditDescription}
+              size="small"
+              className="mt-4 md:mt-0"
+            >
+              <EditIcon />
+            </Fab>
+          </div>
+        )}
+
+        <div className="mt-4 flex flex-col items-center gap-4 md:flex-row">
+          <div className="flex flex-1 flex-col">
+            <Typography variant="subtitle1" className="mb-2 text-gray-700">
+              Data Type:
+            </Typography>
+            <ToggleButtonGroup
+              value={selectedDataType}
+              onChange={handleDataTypeChange}
+              exclusive
+              aria-label="data type"
+              color="primary"
+            >
+              <ToggleButton value="categorical" aria-label="categorical">
+                Categorical
+              </ToggleButton>
+              <ToggleButton value="continuous" aria-label="continuous">
+                Continuous
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </div>
+
+          <div className="flex flex-1 flex-col">
+            <Typography variant="subtitle1" className="mb-2 text-gray-700">
+              Standardized Variable:
+            </Typography>
+            <Autocomplete
+              value={selectedStandardizedVariableKey}
+              onChange={handleStandardizedVariableChange}
+              options={Object.keys(standardizedVariableOptions)}
+              renderInput={(params) => (
+                <TextField
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...params}
+                  variant="outlined"
+                  placeholder="Select a standardized variable"
+                  className="w-full"
+                />
+              )}
+              fullWidth
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ColumnAnnotationCard;

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -76,12 +76,13 @@ function ColumnAnnotationCard({
   };
 
   return (
-    <Card className="mx-auto w-full max-w-5xl shadow-lg">
+    <Card data-cy={`${id}-column-annotation-card`} className="mx-auto w-full max-w-5xl shadow-lg">
       <CardHeader title={header} className="bg-gray-50" />
       <CardContent>
         {isEditingDescription ? (
           <div className="flex flex-col items-center gap-4 md:flex-row">
             <TextField
+              data-cy={`${id}-column-annotation-card-description-input`}
               fullWidth
               multiline
               rows={3}
@@ -92,6 +93,7 @@ function ColumnAnnotationCard({
               className="flex-1"
             />
             <Fab
+              data-cy={`${id}-column-annotation-card-save-description-button`}
               color="secondary"
               aria-label="save"
               onClick={handleSaveDescription}
@@ -106,11 +108,16 @@ function ColumnAnnotationCard({
               <Typography variant="subtitle1" className="mb-2 text-gray-700">
                 Description:
               </Typography>
-              <Typography variant="body1" className="text-gray-700">
+              <Typography
+                data-cy={`${id}-column-annotation-card-description`}
+                variant="body1"
+                className="text-gray-700"
+              >
                 {description || 'No description provided.'}
               </Typography>
             </div>
             <Fab
+              data-cy={`${id}-column-annotation-card-edit-description-button`}
               color="primary"
               aria-label="edit"
               onClick={handleEditDescription}
@@ -128,16 +135,25 @@ function ColumnAnnotationCard({
               Data Type:
             </Typography>
             <ToggleButtonGroup
+              data-cy={`${id}-column-annotation-card-data-type`}
               value={selectedDataType}
               onChange={handleDataTypeChange}
               exclusive
               aria-label="data type"
               color="primary"
             >
-              <ToggleButton value="categorical" aria-label="categorical">
+              <ToggleButton
+                data-cy={`${id}-column-annotation-card-data-type-categorical-button`}
+                value="Categorical"
+                aria-label="categorical"
+              >
                 Categorical
               </ToggleButton>
-              <ToggleButton value="continuous" aria-label="continuous">
+              <ToggleButton
+                data-cy={`${id}-column-annotation-card-data-type-continuous-button`}
+                value="Continuous"
+                aria-label="continuous"
+              >
                 Continuous
               </ToggleButton>
             </ToggleButtonGroup>
@@ -148,6 +164,7 @@ function ColumnAnnotationCard({
               Standardized Variable:
             </Typography>
             <Autocomplete
+              data-cy={`${id}-column-annotation-card-standardized-variable-dropdown`}
               value={selectedStandardizedVariableKey}
               onChange={handleStandardizedVariableChange}
               options={Object.keys(standardizedVariableOptions)}

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -18,11 +18,11 @@ interface ColumnAnnotationCardProps {
   id: number;
   header: string;
   description: string | null;
-  dataType: ['Categorical' | 'Continuous'] | null;
+  dataType: 'Categorical' | 'Continuous' | null;
   standardizedVariable: StandardizedVarible | null;
   standardizedVariableOptions: StandardizedVaribles;
   onDescriptionChange: (columnId: number, newDescription: string | null) => void;
-  onDataTypeChange: (columnId: number, newDataType: ['Categorical' | 'Continuous'] | null) => void;
+  onDataTypeChange: (columnId: number, newDataType: 'Categorical' | 'Continuous' | null) => void;
   onStandardizedVariableChange: (
     columnId: number,
     newStandardizedVariable: StandardizedVarible | null
@@ -42,34 +42,30 @@ function ColumnAnnotationCard({
 }: ColumnAnnotationCardProps) {
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [editedDescription, setEditedDescription] = useState<string | null>(description);
-  const [selectedDataType, setSelectedDataType] = useState<['Categorical' | 'Continuous'] | null>(
+  const [selectedDataType, setSelectedDataType] = useState<'Categorical' | 'Continuous' | null>(
     dataType
   );
   const [selectedStandardizedVariableKey, setSelectedStandardizedVariableKey] = useState<
     string | null
   >(standardizedVariable ? standardizedVariable.identifier : null);
 
-  // Handle description edit
   const handleEditDescription = () => {
     setIsEditingDescription(true);
   };
 
-  // Handle description save
   const handleSaveDescription = () => {
     setIsEditingDescription(false);
     onDescriptionChange(id, editedDescription);
   };
 
-  // Handle data type change
   const handleDataTypeChange = (
     _: React.MouseEvent<HTMLElement>,
-    newDataType: ['Categorical' | 'Continuous'] | null
+    newDataType: 'Categorical' | 'Continuous' | null
   ) => {
     setSelectedDataType(newDataType);
     onDataTypeChange(id, newDataType);
   };
 
-  // Handle standardized variable change
   const handleStandardizedVariableChange = (
     _: React.ChangeEvent<unknown>,
     newValue: string | null

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import {
   Card,
   CardHeader,
@@ -7,12 +6,10 @@ import {
   TextField,
   ToggleButtonGroup,
   ToggleButton,
-  Fab,
   Autocomplete,
 } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import SaveIcon from '@mui/icons-material/Save';
-import { StandardizedVarible, StandardizedVaribles } from '../utils/types';
+import { StandardizedVarible, StandardizedVaribleCollection } from '../utils/types';
+import DescriptionEditor from './DescriptionEditor';
 
 interface ColumnAnnotationCardProps {
   id: number;
@@ -20,7 +17,7 @@ interface ColumnAnnotationCardProps {
   description: string | null;
   dataType: 'Categorical' | 'Continuous' | null;
   standardizedVariable: StandardizedVarible | null;
-  standardizedVariableOptions: StandardizedVaribles;
+  standardizedVariableOptions: StandardizedVaribleCollection;
   onDescriptionChange: (columnId: number, newDescription: string | null) => void;
   onDataTypeChange: (columnId: number, newDataType: 'Categorical' | 'Continuous' | null) => void;
   onStandardizedVariableChange: (
@@ -40,29 +37,10 @@ function ColumnAnnotationCard({
   onDataTypeChange,
   onStandardizedVariableChange,
 }: ColumnAnnotationCardProps) {
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
-  const [editedDescription, setEditedDescription] = useState<string | null>(description);
-  const [selectedDataType, setSelectedDataType] = useState<'Categorical' | 'Continuous' | null>(
-    dataType
-  );
-  const [selectedStandardizedVariableKey, setSelectedStandardizedVariableKey] = useState<
-    string | null
-  >(standardizedVariable ? standardizedVariable.identifier : null);
-
-  const handleEditDescription = () => {
-    setIsEditingDescription(true);
-  };
-
-  const handleSaveDescription = () => {
-    setIsEditingDescription(false);
-    onDescriptionChange(id, editedDescription);
-  };
-
   const handleDataTypeChange = (
     _: React.MouseEvent<HTMLElement>,
     newDataType: 'Categorical' | 'Continuous' | null
   ) => {
-    setSelectedDataType(newDataType);
     onDataTypeChange(id, newDataType);
   };
 
@@ -70,8 +48,10 @@ function ColumnAnnotationCard({
     _: React.ChangeEvent<unknown>,
     newValue: string | null
   ) => {
-    setSelectedStandardizedVariableKey(newValue);
-    const newStandardizedVariable = newValue ? standardizedVariableOptions[newValue] : null;
+    const newStandardizedVariable = newValue
+      ? Object.values(standardizedVariableOptions).find((sv) => sv.label === newValue) || null
+      : null;
+
     onStandardizedVariableChange(id, newStandardizedVariable);
   };
 
@@ -79,56 +59,11 @@ function ColumnAnnotationCard({
     <Card data-cy={`${id}-column-annotation-card`} className="mx-auto w-full max-w-5xl shadow-lg">
       <CardHeader title={header} className="bg-gray-50" />
       <CardContent>
-        {isEditingDescription ? (
-          <div className="flex flex-col items-center gap-4 md:flex-row">
-            <TextField
-              data-cy={`${id}-column-annotation-card-description-input`}
-              fullWidth
-              multiline
-              rows={3}
-              value={editedDescription || ''}
-              onChange={(e) => setEditedDescription(e.target.value)}
-              variant="outlined"
-              label="Description"
-              className="flex-1"
-            />
-            <Fab
-              data-cy={`${id}-column-annotation-card-save-description-button`}
-              color="secondary"
-              aria-label="save"
-              onClick={handleSaveDescription}
-              size="small"
-              className="mt-4 md:mt-0"
-            >
-              <SaveIcon />
-            </Fab>
-          </div>
-        ) : (
-          <div className="flex flex-col items-center gap-4 md:flex-row">
-            <div className="flex-1">
-              <Typography variant="subtitle1" className="mb-2 text-gray-700">
-                Description:
-              </Typography>
-              <Typography
-                data-cy={`${id}-column-annotation-card-description`}
-                variant="body1"
-                className="text-gray-700"
-              >
-                {description || 'No description provided.'}
-              </Typography>
-            </div>
-            <Fab
-              data-cy={`${id}-column-annotation-card-edit-description-button`}
-              color="primary"
-              aria-label="edit"
-              onClick={handleEditDescription}
-              size="small"
-              className="mt-4 md:mt-0"
-            >
-              <EditIcon />
-            </Fab>
-          </div>
-        )}
+        <DescriptionEditor
+          description={description}
+          onDescriptionChange={onDescriptionChange}
+          id={id}
+        />
 
         <div className="mt-4 flex flex-col items-center gap-4 md:flex-row">
           <div className="flex flex-1 flex-col">
@@ -137,23 +72,20 @@ function ColumnAnnotationCard({
             </Typography>
             <ToggleButtonGroup
               data-cy={`${id}-column-annotation-card-data-type`}
-              value={selectedDataType}
+              value={dataType}
               onChange={handleDataTypeChange}
               exclusive
-              aria-label="data type"
               color="primary"
             >
               <ToggleButton
                 data-cy={`${id}-column-annotation-card-data-type-categorical-button`}
                 value="Categorical"
-                aria-label="categorical"
               >
                 Categorical
               </ToggleButton>
               <ToggleButton
                 data-cy={`${id}-column-annotation-card-data-type-continuous-button`}
                 value="Continuous"
-                aria-label="continuous"
               >
                 Continuous
               </ToggleButton>
@@ -166,9 +98,9 @@ function ColumnAnnotationCard({
             </Typography>
             <Autocomplete
               data-cy={`${id}-column-annotation-card-standardized-variable-dropdown`}
-              value={selectedStandardizedVariableKey}
+              value={standardizedVariable?.label}
               onChange={handleStandardizedVariableChange}
-              options={Object.keys(standardizedVariableOptions)}
+              options={Object.entries(standardizedVariableOptions).map(([_, value]) => value.label)}
               renderInput={(params) => (
                 <TextField
                   // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -98,7 +98,7 @@ function ColumnAnnotationCard({
             </Typography>
             <Autocomplete
               data-cy={`${id}-column-annotation-card-standardized-variable-dropdown`}
-              value={standardizedVariable?.label}
+              value={standardizedVariable?.label || ''}
               onChange={handleStandardizedVariableChange}
               options={Object.entries(standardizedVariableOptions).map(([_, value]) => value.label)}
               renderInput={(params) => (

--- a/src/components/DescriptionEditor.tsx
+++ b/src/components/DescriptionEditor.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { Fab, TextField, Typography } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+
+interface DescriptionEditorProps {
+  description: string | null;
+  onDescriptionChange: (id: number, description: string | null) => void;
+  id: number;
+}
+
+function DescriptionEditor({ description, onDescriptionChange, id }: DescriptionEditorProps) {
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [editedDescription, setEditedDescription] = useState<string | null>(description);
+
+  const handleEditDescription = () => {
+    setIsEditingDescription(true);
+  };
+
+  const handleSaveDescription = () => {
+    setIsEditingDescription(false);
+    onDescriptionChange(id, editedDescription);
+  };
+
+  return isEditingDescription ? (
+    <div className="flex flex-col items-center gap-4 md:flex-row">
+      <TextField
+        data-cy={`${id}-description-input`}
+        fullWidth
+        multiline
+        rows={3}
+        value={editedDescription || ''}
+        onChange={(e) => setEditedDescription(e.target.value)}
+        variant="outlined"
+        label="Description"
+        className="flex-1"
+      />
+      <Fab
+        data-cy={`${id}-save-description-button`}
+        color="secondary"
+        onClick={handleSaveDescription}
+        size="small"
+        className="mt-4 md:mt-0"
+      >
+        <SaveIcon />
+      </Fab>
+    </div>
+  ) : (
+    <div className="flex flex-col items-center gap-4 md:flex-row">
+      <div className="flex-1">
+        <Typography variant="subtitle1" className="mb-2 text-gray-700">
+          Description:
+        </Typography>
+        <Typography data-cy={`${id}-description`} variant="body1" className="text-gray-700">
+          {description || 'No description provided.'}
+        </Typography>
+      </div>
+      <Fab
+        data-cy={`${id}-edit-description-button`}
+        color="primary"
+        onClick={handleEditDescription}
+        size="small"
+        className="mt-4 md:mt-0"
+      >
+        <EditIcon />
+      </Fab>
+    </div>
+  );
+}
+
+export default DescriptionEditor;

--- a/src/components/UploadCard.tsx
+++ b/src/components/UploadCard.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Button, Card, Typography, Collapse } from '@mui/material';
+import { Button, Card, CardHeader, CardContent, Typography, Collapse } from '@mui/material';
 import { ExpandMore, ExpandLess } from '@mui/icons-material';
 import FileUploader from './FileUploader';
 
@@ -66,46 +66,45 @@ function UploadCard({
   };
 
   return (
-    <div className="mx-auto w-full max-w-[1024px] px-4">
+    <div className="mx-auto w-full max-w-[1024px] rounded-3xl shadow-lg">
       <Card
         data-cy={`${title}-upload-card`}
-        className="rounded-3xl border-2 border-solid border-gray-300 p-4 text-center"
+        className="rounded-3xl border-2 border-solid border-gray-300 text-center"
       >
-        <Typography variant="h5" component="h2" className="mb-4 text-left">
-          {title}
-        </Typography>
+        <CardHeader title={title} className="bg-gray-50 text-left" />
+        <CardContent>
+          <FileUploader
+            displayText={FileUploaderDisplayText}
+            handleClickToUpload={handleClickToUpload}
+            handleDrop={handleDrop}
+            handleDragOver={handleDragOver}
+            handleFileUpload={handleFileUpload}
+            fileInputRef={fileInputRef}
+            allowedFileType={allowedFileType}
+            disabled={diableFileUploader}
+            tooltipContent={FileUploaderToolTipContent}
+          />
 
-        <FileUploader
-          displayText={FileUploaderDisplayText}
-          handleClickToUpload={handleClickToUpload}
-          handleDrop={handleDrop}
-          handleDragOver={handleDragOver}
-          handleFileUpload={handleFileUpload}
-          fileInputRef={fileInputRef}
-          allowedFileType={allowedFileType}
-          disabled={diableFileUploader}
-          tooltipContent={FileUploaderToolTipContent}
-        />
-
-        {isFileUploaded && (
-          <div className="mt-4">
-            <Typography
-              variant="body1"
-              className="mb-2"
-              data-cy={`${title}-card-uploaded-file-name`}
-            >
-              <strong>{uploadedFileName}</strong>
-            </Typography>
-            <Button
-              data-cy={`toggle-${title}-card-preview`}
-              variant="outlined"
-              onClick={togglePreview}
-              endIcon={isPreviewOpen ? <ExpandLess /> : <ExpandMore />}
-            >
-              {isPreviewOpen ? 'Hide Preview' : 'Show Preview'}
-            </Button>
-          </div>
-        )}
+          {isFileUploaded && (
+            <div className="mt-4">
+              <Typography
+                variant="body1"
+                className="mb-2"
+                data-cy={`${title}-card-uploaded-file-name`}
+              >
+                <strong>{uploadedFileName}</strong>
+              </Typography>
+              <Button
+                data-cy={`toggle-${title}-card-preview`}
+                variant="outlined"
+                onClick={togglePreview}
+                endIcon={isPreviewOpen ? <ExpandLess /> : <ExpandMore />}
+              >
+                {isPreviewOpen ? 'Hide Preview' : 'Show Preview'}
+              </Button>
+            </div>
+          )}
+        </CardContent>
       </Card>
 
       <Collapse in={isPreviewOpen} timeout="auto" unmountOnExit>

--- a/src/stores/data.test.ts
+++ b/src/stores/data.test.ts
@@ -7,7 +7,7 @@ import * as R from 'ramda';
 import useDataStore from './data';
 
 describe('store actions', () => {
-  it('should process a data table file and update dataTable, columns, and uploadedDataTableFileName', async () => {
+  it('processes a data table file and update dataTable, columns, and uploadedDataTableFileName', async () => {
     const { result } = renderHook(() => useDataStore());
 
     const dataTableFilePath = path.resolve(__dirname, '../../cypress/fixtures/examples/mock.tsv');
@@ -25,7 +25,7 @@ describe('store actions', () => {
     expect(result.current.uploadedDataTableFileName).toEqual('mock.tsv');
   });
 
-  it('should process a data dictionary file and update columns and uploadedDataDictionaryFileName', async () => {
+  it('processes a data dictionary file and update columns and uploadedDataDictionaryFileName', async () => {
     const { result } = renderHook(() => useDataStore());
 
     // Set the initial columns to `mockInitialColumns`
@@ -65,5 +65,28 @@ describe('store actions', () => {
     });
     expect(result.current.columns).toEqual(mockUpdatedColumns);
     expect(result.current.uploadedDataDictionaryFileName).toEqual('mock.json');
+  });
+  it('updates the description field of a column', () => {
+    const { result } = renderHook(() => useDataStore());
+    act(() => {
+      result.current.updateColumnDescription(1, 'some description');
+    });
+    expect(result.current.columns['1'].description).toEqual('some description');
+  });
+
+  it('updates the dataType field of a column', () => {
+    const { result } = renderHook(() => useDataStore());
+    act(() => {
+      result.current.updateColumnDataType(1, 'Continuous');
+    });
+    expect(result.current.columns['1'].dataType).toEqual('Continuous');
+  });
+
+  it('updates the standardizedVariable field of a column', () => {
+    const { result } = renderHook(() => useDataStore());
+    act(() => {
+      result.current.updateColumnStandardizedVariable(1, { identifier: 'nb:Some' });
+    });
+    expect(result.current.columns['1'].standardizedVariable).toEqual({ identifier: 'nb:Some' });
   });
 });

--- a/src/stores/data.test.ts
+++ b/src/stores/data.test.ts
@@ -85,8 +85,11 @@ describe('store actions', () => {
   it('updates the standardizedVariable field of a column', () => {
     const { result } = renderHook(() => useDataStore());
     act(() => {
-      result.current.updateColumnStandardizedVariable(1, { identifier: 'nb:Some' });
+      result.current.updateColumnStandardizedVariable(1, { identifier: 'nb:Some', label: 'Some' });
     });
-    expect(result.current.columns['1'].standardizedVariable).toEqual({ identifier: 'nb:Some' });
+    expect(result.current.columns['1'].standardizedVariable).toEqual({
+      identifier: 'nb:Some',
+      label: 'Some',
+    });
   });
 });

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -18,7 +18,7 @@ type DataStore = {
   setUploadedDataTableFileName: (fileName: string | null) => void;
   processDataTableFile: (file: File) => Promise<void>;
   updateColumnDescription: (columnId: number, description: string | null) => void;
-  updateColumnDataType: (columnId: number, dataType: ['Categorical' | 'Continuous'] | null) => void;
+  updateColumnDataType: (columnId: number, dataType: 'Categorical' | 'Continuous' | null) => void;
   updateColumnStandardizedVariable: (
     columnId: number,
     standardizedVariable: StandardizedVarible | null
@@ -85,7 +85,7 @@ const useDataStore = create<DataStore>((set, get) => ({
     }));
   },
 
-  updateColumnDataType: (columnId: number, dataType: ['Categorical' | 'Continuous'] | null) => {
+  updateColumnDataType: (columnId: number, dataType: 'Categorical' | 'Continuous' | null) => {
     set((state) => ({
       columns: R.assocPath([columnId, 'dataType'], dataType, state.columns),
     }));

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -1,20 +1,36 @@
 import { create } from 'zustand';
 import * as R from 'ramda';
-import { DataTable, Columns, DataDictionary } from '../utils/types';
+import defaultConfig from '../../configs/default.json';
+import {
+  DataTable,
+  Columns,
+  DataDictionary,
+  StandardizedVaribles,
+  StandardizedVarible,
+} from '../utils/types';
 
 type DataStore = {
   dataTable: DataTable;
   columns: Columns;
-  uploadedDataDictionary: DataDictionary;
   uploadedDataTableFileName: string | null;
-  uploadedDataDictionaryFileName: string | null;
   setDataTable: (data: DataTable) => void;
   initializeColumns: (data: Columns) => void;
-  setDataDictionary: (data: DataDictionary) => void;
   setUploadedDataTableFileName: (fileName: string | null) => void;
-  setUploadedDataDictionaryFileName: (fileName: string | null) => void;
   processDataTableFile: (file: File) => Promise<void>;
+  updateColumnDescription: (columnId: number, description: string | null) => void;
+  updateColumnDataType: (columnId: number, dataType: ['Categorical' | 'Continuous'] | null) => void;
+  updateColumnStandardizedVariable: (
+    columnId: number,
+    standardizedVariable: StandardizedVarible | null
+  ) => void;
+
+  uploadedDataDictionary: DataDictionary;
+  uploadedDataDictionaryFileName: string | null;
+  setDataDictionary: (data: DataDictionary) => void;
+  setUploadedDataDictionaryFileName: (fileName: string | null) => void;
   processDataDictionaryFile: (file: File) => Promise<void>;
+
+  standardizedVaribles: StandardizedVaribles;
 };
 
 const useDataStore = create<DataStore>((set, get) => ({
@@ -62,6 +78,27 @@ const useDataStore = create<DataStore>((set, get) => ({
 
       reader.readAsText(file);
     }),
+
+  updateColumnDescription: (columnId: number, description: string | null) => {
+    set((state) => ({
+      columns: R.assocPath([columnId, 'description'], description, state.columns),
+    }));
+  },
+
+  updateColumnDataType: (columnId: number, dataType: ['Categorical' | 'Continuous'] | null) => {
+    set((state) => ({
+      columns: R.assocPath([columnId, 'dataType'], dataType, state.columns),
+    }));
+  },
+
+  updateColumnStandardizedVariable: (
+    columnId: number,
+    standardizedVariable: StandardizedVarible | null
+  ) => {
+    set((state) => ({
+      columns: R.assocPath([columnId, 'standardizedVariable'], standardizedVariable, state.columns),
+    }));
+  },
 
   // Data dictionary
   uploadedDataDictionary: {},
@@ -115,6 +152,9 @@ const useDataStore = create<DataStore>((set, get) => ({
 
       reader.readAsText(file);
     }),
+
+  // Config
+  standardizedVaribles: defaultConfig.standardizedVariables,
 }));
 
 export default useDataStore;

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -5,7 +5,7 @@ import {
   DataTable,
   Columns,
   DataDictionary,
-  StandardizedVaribles,
+  StandardizedVaribleCollection,
   StandardizedVarible,
 } from '../utils/types';
 
@@ -30,7 +30,7 @@ type DataStore = {
   setUploadedDataDictionaryFileName: (fileName: string | null) => void;
   processDataDictionaryFile: (file: File) => Promise<void>;
 
-  standardizedVaribles: StandardizedVaribles;
+  standardizedVaribles: StandardizedVaribleCollection;
 };
 
 const useDataStore = create<DataStore>((set, get) => ({

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,8 +11,17 @@ const NBTheme = createTheme({
   },
   components: {
     MuiButton: {
-      defaultProps: {
-        sx: { textTransform: 'none' },
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
       },
     },
   },

--- a/src/utils/mocks.ts
+++ b/src/utils/mocks.ts
@@ -78,20 +78,26 @@ export const mockDataDictionary = {
 export const mockStandardizedVariables = {
   'Subject ID': {
     identifier: 'nb:ParticipantID',
+    label: 'Participant ID',
   },
   'Session ID': {
     identifier: 'nb:SessionID',
+    label: 'Session ID',
   },
   Age: {
     identifier: 'nb:Age',
+    label: 'Age',
   },
   Sex: {
     identifier: 'nb:Sex',
+    label: 'Sex',
   },
   Diagnosis: {
     identifier: 'nb:Diagnosis',
+    label: 'Diagnosis',
   },
   'Assessment Tool': {
     identifier: 'nb:AssessmentTool',
+    label: 'Assessment Tool',
   },
 };

--- a/src/utils/mocks.ts
+++ b/src/utils/mocks.ts
@@ -74,3 +74,24 @@ export const mockDataDictionary = {
     },
   },
 };
+
+export const mockStandardizedVariables = {
+  'Subject ID': {
+    identifier: 'nb:ParticipantID',
+  },
+  'Session ID': {
+    identifier: 'nb:SessionID',
+  },
+  Age: {
+    identifier: 'nb:Age',
+  },
+  Sex: {
+    identifier: 'nb:Sex',
+  },
+  Diagnosis: {
+    identifier: 'nb:Diagnosis',
+  },
+  'Assessment Tool': {
+    identifier: 'nb:AssessmentTool',
+  },
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -40,8 +40,9 @@ export interface DataDictionary {
 
 export interface StandardizedVarible {
   identifier: string;
+  label: string;
 }
 
-export interface StandardizedVaribles {
+export interface StandardizedVaribleCollection {
   [key: string]: StandardizedVarible;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,7 +4,7 @@ export type DataTable = {
 export type Column = {
   header: string;
   description?: string | null;
-  dataType?: ['Categorical' | 'Continuous'] | null;
+  dataType?: 'Categorical' | 'Continuous' | null;
   standardizedVariable?: StandardizedVarible | null;
 };
 export type Columns = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,7 +3,9 @@ export type DataTable = {
 };
 export type Column = {
   header: string;
-  description?: string;
+  description?: string | null;
+  dataType?: ['Categorical' | 'Continuous'] | null;
+  standardizedVariable?: StandardizedVarible | null;
 };
 export type Columns = {
   [key: number]: Column;
@@ -34,4 +36,12 @@ export interface DataDictionary {
       MissingValues?: string[];
     };
   };
+}
+
+export interface StandardizedVarible {
+  identifier: string;
+}
+
+export interface StandardizedVaribles {
+  [key: string]: StandardizedVarible;
 }


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #51 
- Closes #53 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Implement column annotation functionality, allowing users to view and edit column metadata. Introduce a new `ColumnAnnotationCard` component for individual column annotation and integrate it into a paginated `ColumnAnnotation` view. Enhance the data store to manage and persist column metadata changes.

New Features:
- Implement a `ColumnAnnotationCard` component that allows users to view and edit column metadata, including description, data type, and standardized variable.
- Add a `ColumnAnnotation` component to display a paginated list of `ColumnAnnotationCard` components.
- Integrate the new components with the data store to persist changes to column metadata.
- Add a configuration file to store default standardized variables.

Enhancements:
- Refactor the `UploadCard` component to use Material UI's `CardHeader` and `CardContent` components for improved structure and styling.

Tests:
- Add Cypress component tests for the `ColumnAnnotationCard` component.