### PR TITLE
[ENH] Disabled `next` button on `Upload` step when no data table is uploaded

### DIFF
--- a/cypress/component/NavigationButton.cy.tsx
+++ b/cypress/component/NavigationButton.cy.tsx
@@ -39,4 +39,18 @@ describe('NavigationButton', () => {
 
     cy.get('@setCurrentViewSpy').should('have.been.calledWith', props.nextView);
   });
+  it('should disable buttons when disable props are true', () => {
+    cy.mount(
+      <NavigationButton
+        backView={props.backView}
+        nextView={props.nextView}
+        backLabel="Back"
+        nextLabel="Next"
+        disableBack
+        disableNext
+      />
+    );
+    cy.get('[data-cy="back-button"]').should('be.disabled');
+    cy.get('[data-cy="next-button"]').should('be.disabled');
+  });
 });

--- a/cypress/e2e/MainUserFlow.cy.ts
+++ b/cypress/e2e/MainUserFlow.cy.ts
@@ -39,7 +39,7 @@ describe('Main user flow', () => {
 
     // Upload view
     cy.get('[data-cy="back-button"]').should('contain', 'Landing');
-    cy.get('[data-cy="next-button"]').should('contain', 'Column Annotation');
+    cy.get('[data-cy="next-button"]').should('contain', 'Column Annotation').and('be.disabled');
     cy.get('[data-cy="nav-stepper"]').should('be.visible');
     cy.get('[data-cy="Upload-step"]').within(() => {
       cy.get('.MuiStepLabel-iconContainer').should('have.class', 'Mui-active');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ function App() {
   const setCurrentView = useViewStore((state) => state.setCurrentView);
   const hasMultiColumnMeasures = useDataStore((state) => state.hasMultiColumnMeasures());
 
+  const disableUploadNextButton = useDataStore((state) => state.uploadedDataTableFileName == null);
+
   const theme = useTheme();
   const appBarHeight = theme.mixins.toolbar.minHeight || 64;
 
@@ -80,6 +82,7 @@ function App() {
       {currentView !== View.Landing && (
         <div className="mt-auto">
           <NavigationButton
+            disableNext={disableUploadNextButton}
             backView={backView}
             nextView={nextView}
             backLabel={backLabel}

--- a/src/components/NavigationButton.tsx
+++ b/src/components/NavigationButton.tsx
@@ -5,6 +5,8 @@ import { View } from '../utils/internal_types';
 const defaultProps = {
   backLabel: 'Back',
   nextLabel: 'Next',
+  disableBack: false,
+  disableNext: false,
   styleClassName: '',
 };
 
@@ -13,12 +15,16 @@ function NavigationButton({
   nextView,
   backLabel,
   nextLabel,
+  disableBack,
+  disableNext,
   styleClassName,
 }: {
   backView: View | undefined;
   nextView: View | undefined;
   backLabel?: string;
   nextLabel?: string;
+  disableBack?: boolean;
+  disableNext?: boolean;
   styleClassName?: string;
 }) {
   const setCurrentView = useViewStore((state) => state.setCurrentView);
@@ -38,12 +44,22 @@ function NavigationButton({
   return (
     <div className={`flex flex-row justify-between ${styleClassName}`}>
       {backView && (
-        <Button data-cy="back-button" variant="contained" onClick={handleBack}>
+        <Button
+          data-cy="back-button"
+          disabled={disableBack}
+          variant="contained"
+          onClick={handleBack}
+        >
           {backLabel}
         </Button>
       )}
       {nextView && (
-        <Button data-cy="next-button" variant="contained" onClick={handleNext}>
+        <Button
+          data-cy="next-button"
+          disabled={disableNext}
+          variant="contained"
+          onClick={handleNext}
+        >
           {nextLabel}
         </Button>
       )}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #231 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Disable navigation buttons based on new props and prevent advancing from the Upload step when no data table is uploaded.

Enhancements:
- Introduce disableBack and disableNext props to NavigationButton to control its disabled state
- Wire disableNext in App to disable the Next button on the Upload step when no data table has been uploaded

Tests:
- Add component test to verify NavigationButton respects disableBack and disableNext props
- Update main user flow e2e test to assert the Next button on the Upload step is disabled before uploading a data table