### PR TITLE
[ENH] Prefixed assessment terms with abbreviations

### DIFF
--- a/src/components/MultiColumnMeasuresCard.tsx
+++ b/src/components/MultiColumnMeasuresCard.tsx
@@ -46,13 +46,17 @@ function MultiColumnMeasuresCard({
         title={
           card.term ? (
             <Typography variant="h6" className="font-bold">
-              {card.term.label}
+              {card.term.abbreviation
+                ? `${card.term.abbreviation} - ${card.term.label}`
+                : card.term.label}
             </Typography>
           ) : (
             <Autocomplete
               data-cy={`multi-column-measures-card-${cardIndex}-title-dropdown`}
               options={availableTerms}
-              getOptionLabel={(option: MultiColumnMeasuresTerm) => option.label}
+              getOptionLabel={(option: MultiColumnMeasuresTerm) =>
+                option.abbreviation ? `${option.abbreviation} - ${option.label}` : option.label
+              }
               getOptionDisabled={(option) => option.disabled || false}
               onChange={(_, newValue) => onTermSelect(newValue)}
               renderInput={(params) => (


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #286 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Prefix assessment term labels with their abbreviations in the MultiColumnMeasuresCard component for both the card title and dropdown options

Enhancements:
- Display abbreviation before term label in card title when available
- Include abbreviation in autocomplete option labels when available