### PR TITLE
[TST] Add regression test for config change 

### DIFF
--- a/cypress/e2e/ConfigChangeRegression.cy.ts
+++ b/cypress/e2e/ConfigChangeRegression.cy.ts
@@ -1,23 +1,32 @@
-import defaultAssessmentTerms from '../../src/assets/default_config/assessment.json';
 import defaultConfig from '../../src/assets/default_config/config.json';
 import defaultDiagnosisTerms from '../../src/assets/default_config/diagnosis.json';
 import defaultSexTerms from '../../src/assets/default_config/sex.json';
 import { mockDataTableFilePath } from '../support/testConstants';
 
-const coolConfig = {
+const oldAssessmentTerms = [
+  {
+    namespace_prefix: 'neurobagel',
+    namespace_url: 'https://old.com/asse/terms/',
+    vocabulary_name: 'Neurobagel Assessments',
+    version: '1.0.0',
+    terms: [{ id: 'old_id', name: 'Old Name' }],
+  },
+];
+
+const newConfig = {
   ...defaultConfig[0],
-  vocabulary_name: 'Cool Vocab',
-  namespace_prefix: 'cool',
+  vocabulary_name: 'New Vocab',
+  namespace_prefix: 'new',
 };
 
-const coolAssessmentTerms = [
+const newAssessmentTerms = [
   {
-    namespace_prefix: 'cool',
-    namespace_url: 'https://cool.org/pd/terms/',
-    vocabulary_name: 'cool Assessments',
+    namespace_prefix: 'new',
+    namespace_url: 'https://new.org/pd/terms/',
+    vocabulary_name: 'new Assessments',
     version: '1.0.0',
     terms: [
-      { id: 'cool_id', name: 'Cool Name' },
+      { id: 'new_id', name: 'New Name' },
       { id: 'another_id', name: 'Another Name' },
     ],
   },
@@ -25,11 +34,11 @@ const coolAssessmentTerms = [
 
 describe('Config Change Regression', () => {
   beforeEach(() => {
-    // Serve two remote configs so we can swap from Neurobagel to Cool mid-flow
+    // Serve two remote configs so we can swap from Neurobagel to New mid-flow
     cy.intercept('GET', 'https://api.github.com/repos/neurobagel/communities/contents/configs', {
       body: [
         { type: 'dir', name: 'Neurobagel' },
-        { type: 'dir', name: 'Cool' },
+        { type: 'dir', name: 'New' },
       ],
     }).as('configList');
 
@@ -43,7 +52,7 @@ describe('Config Change Regression', () => {
     cy.intercept(
       'GET',
       'https://raw.githubusercontent.com/neurobagel/communities/main/configs/Neurobagel/assessment.json',
-      { body: defaultAssessmentTerms }
+      { body: oldAssessmentTerms }
     ).as('nbAssessment');
     cy.intercept(
       'GET',
@@ -58,24 +67,24 @@ describe('Config Change Regression', () => {
 
     cy.intercept(
       'GET',
-      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/Cool/config.json',
-      { body: [coolConfig] }
-    ).as('coolConfig');
+      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/New/config.json',
+      { body: [newConfig] }
+    ).as('newConfig');
     cy.intercept(
       'GET',
-      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/Cool/assessment.json',
-      { body: coolAssessmentTerms }
-    ).as('coolAssessment');
+      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/New/assessment.json',
+      { body: newAssessmentTerms }
+    ).as('newAssessment');
     cy.intercept(
       'GET',
-      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/Cool/diagnosis.json',
+      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/New/diagnosis.json',
       { body: defaultDiagnosisTerms }
-    ).as('coolDiagnosis');
+    ).as('newDiagnosis');
     cy.intercept(
       'GET',
-      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/Cool/sex.json',
+      'https://raw.githubusercontent.com/neurobagel/communities/main/configs/New/sex.json',
       { body: defaultSexTerms }
-    ).as('coolSex');
+    ).as('newSex');
   });
 
   it('Should update assessment vocabulary after changing configs', () => {
@@ -85,7 +94,7 @@ describe('Config Change Regression', () => {
     // Upload view - Select Neurobagel config
     cy.wait('@configList');
     cy.get('[data-cy="config-card-dropdown"] input').should('have.value', 'Neurobagel');
-    cy.get('[data-config-loading="false"] ').should('exist');
+    cy.get('[data-config-loading="false"]').should('exist');
 
     cy.get('[data-cy="datatable-upload-input"]').selectFile(mockDataTableFilePath, {
       force: true,
@@ -103,13 +112,13 @@ describe('Config Change Regression', () => {
     cy.get('[data-cy="multi-column-measures-tab-Assessment Tool"]').should('be.visible');
     cy.get('[data-cy="add-term-card-button"]').click();
     cy.get('[data-cy="multi-column-measures-card-0-title-dropdown"]').click();
-    cy.get('ul[role="listbox"]').should('contain', 'Robson Ten Group Classification System');
+    cy.get('ul[role="listbox"]').should('contain', 'Old Name');
     cy.get('[data-cy="back-button"]').click();
     cy.get('[data-cy="back-button"]').click();
 
-    // Upload view - Change to "Cool" config and wait for its vocab to load
-    cy.get('[data-cy="config-card-dropdown"]').type('cool{downArrow}{enter}');
-    cy.wait(['@coolConfig', '@coolAssessment', '@coolDiagnosis', '@coolSex']);
+    // Upload view - Change to "New" config and wait for its vocab to load
+    cy.get('[data-cy="config-card-dropdown"]').type('new{downArrow}{enter}');
+    cy.wait(['@newConfig', '@newAssessment', '@newDiagnosis', '@newSex']);
 
     // Re-run annotation using the new config to ensure we see the refreshed vocab
     cy.get('[data-cy="next-button"]').click();
@@ -119,11 +128,11 @@ describe('Config Change Regression', () => {
     );
     cy.get('[data-cy="next-button"]').click();
 
-    // New assessment terms from "Cool" should replace the Neurobagel list
+    // New assessment terms from "New" should replace the Neurobagel list
     cy.get('[data-cy="multi-column-measures-tab-Assessment Tool"]').should('be.visible');
     cy.get('[data-cy="add-term-card-button"]').click();
     cy.get('[data-cy="multi-column-measures-card-0-title-dropdown"]').click();
-    cy.get('ul[role="listbox"]').should('contain', 'Cool Name');
-    cy.get('ul[role="listbox"]').should('not.contain', 'Robson Ten Group Classification System');
+    cy.get('ul[role="listbox"]').should('contain', 'New Name');
+    cy.get('ul[role="listbox"]').should('not.contain', 'Old Name');
   });
 });


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #322 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added regression test for config switch, the test essentially checks that the terms in the dropdown on multi column measure view  are updated after config is changed

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Tests:
- Add Cypress regression test covering config switching and verifying multi-column measure dropdown terms update from the new vocabulary.