### PR TITLE
[REF] Factor out data type toggle into standalone DataTypeToggle component

### DIFF
--- a/cypress/component/DataTypeToggle.cy.tsx
+++ b/cypress/component/DataTypeToggle.cy.tsx
@@ -1,0 +1,63 @@
+import { DataType } from '~/utils/internal_types';
+import DataTypeToggle from '../../src/components/DataTypeToggle';
+
+const props = {
+  columnId: '1',
+  value: DataType.categorical,
+  isEditable: true,
+  inferredLabel: null as string | null,
+  onChange: () => {},
+};
+
+describe('DataTypeToggle', () => {
+  beforeEach(() => {
+    cy.mount(
+      <DataTypeToggle
+        columnId={props.columnId}
+        value={props.value}
+        isEditable={props.isEditable}
+        inferredLabel={props.inferredLabel}
+        onChange={props.onChange}
+      />
+    );
+  });
+
+  it('renders the component', () => {
+    cy.get('[data-cy="1-column-annotation-card-data-type"]').should('be.visible');
+    cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
+      'be.visible'
+    );
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').should('be.visible');
+  });
+
+  it('Fires the onChange event handler with the appropriate payload when the data type is toggled', () => {
+    const spy = cy.spy().as('spy');
+
+    cy.mount(
+      <DataTypeToggle
+        columnId={props.columnId}
+        value={props.value}
+        isEditable={props.isEditable}
+        inferredLabel={props.inferredLabel}
+        onChange={spy}
+      />
+    );
+
+    cy.get('[data-cy="1-column-annotation-card-data-type-continuous-button"]').click();
+    cy.get('@spy').should('have.been.calledWith', '1', 'Continuous');
+  });
+
+  it('shows inferred label when data type is locked', () => {
+    cy.mount(
+      <DataTypeToggle
+        columnId="2"
+        value={null}
+        isEditable={false}
+        inferredLabel="Identifier"
+        onChange={props.onChange}
+      />
+    );
+
+    cy.get('[data-cy="2-column-annotation-card-data-type"]').should('contain', 'Identifier');
+  });
+});

--- a/cypress/component/DataTypeToggle.cy.tsx
+++ b/cypress/component/DataTypeToggle.cy.tsx
@@ -60,4 +60,35 @@ describe('DataTypeToggle', () => {
 
     cy.get('[data-cy="2-column-annotation-card-data-type"]').should('contain', 'Identifier');
   });
+
+  it('displays the value prop in locked state when inferredLabel is null', () => {
+    cy.mount(
+      <DataTypeToggle
+        columnId="3"
+        value={DataType.categorical}
+        isEditable={false}
+        inferredLabel={null}
+        onChange={props.onChange}
+      />
+    );
+
+    cy.get('[data-cy="3-column-annotation-card-data-type"]').should(
+      'contain',
+      DataType.categorical
+    );
+  });
+
+  it("displays 'Unknown' in locked state when both inferredLabel and value are null", () => {
+    cy.mount(
+      <DataTypeToggle
+        columnId="4"
+        value={null}
+        isEditable={false}
+        inferredLabel={null}
+        onChange={props.onChange}
+      />
+    );
+
+    cy.get('[data-cy="4-column-annotation-card-data-type"]').should('contain', 'Unknown');
+  });
 });

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -1,14 +1,7 @@
-import HelpIcon from '@mui/icons-material/Help';
-import {
-  Typography,
-  ToggleButtonGroup,
-  ToggleButton,
-  Autocomplete,
-  Tooltip,
-  TextField,
-} from '@mui/material';
+import { Typography, Autocomplete, TextField } from '@mui/material';
 import { DataType } from '~/utils/internal_types';
 import { StandardizedVariableOption } from '../hooks/useStandardizedVariableOptions';
+import DataTypeToggle from './DataTypeToggle';
 import DescriptionEditor from './DescriptionEditor';
 
 interface ColumnAnnotationCardProps {
@@ -64,57 +57,13 @@ function ColumnAnnotationCard({
         </div>
 
         <div className="flex-shrink-0">
-          {isDataTypeEditable ? (
-            <ToggleButtonGroup
-              data-cy={`${id}-column-annotation-card-data-type`}
-              value={dataType}
-              onChange={(_, newDataType) => onDataTypeChange(id, newDataType)}
-              exclusive
-              color="primary"
-              size="small"
-              className="shadow-sm w-full flex h-10"
-            >
-              <Tooltip title="Categorical" arrow>
-                <ToggleButton
-                  data-cy={`${id}-column-annotation-card-data-type-categorical-button`}
-                  value="Categorical"
-                  className="px-2 flex-1 w-1/2"
-                >
-                  <span className="text-xs font-semibold">Cat.</span>
-                </ToggleButton>
-              </Tooltip>
-
-              <Tooltip title="Continuous" arrow>
-                <ToggleButton
-                  data-cy={`${id}-column-annotation-card-data-type-continuous-button`}
-                  value="Continuous"
-                  className="px-2 flex-1 w-1/2"
-                >
-                  <span className="text-xs font-semibold">Cont.</span>
-                </ToggleButton>
-              </Tooltip>
-            </ToggleButtonGroup>
-          ) : (
-            <Tooltip
-              title={
-                'Data type is automatically determined by standardized variable selection. \n' +
-                ' To change the data type manually, remove the standardized variable'
-              }
-              arrow
-            >
-              <div
-                className="h-10 px-2 flex items-center justify-center border rounded border-gray-200 bg-gray-50/50 text-gray-500 cursor-not-allowed w-full shadow-sm"
-                data-cy={`${id}-column-annotation-card-data-type`}
-                tabIndex={0}
-                role="button"
-              >
-                <Typography variant="caption" className="font-medium truncate">
-                  {inferredDataTypeLabel || dataType || 'Unknown'}
-                </Typography>
-                <HelpIcon sx={{ fontSize: 14 }} className="text-gray-400 ml-1" />
-              </div>
-            </Tooltip>
-          )}
+          <DataTypeToggle
+            columnId={id}
+            value={dataType}
+            isEditable={isDataTypeEditable}
+            inferredLabel={inferredDataTypeLabel}
+            onChange={onDataTypeChange}
+          />
         </div>
 
         <div className="flex-shrink-0 w-full">

--- a/src/components/DataTypeToggle.tsx
+++ b/src/components/DataTypeToggle.tsx
@@ -1,0 +1,77 @@
+import HelpIcon from '@mui/icons-material/Help';
+import { ToggleButtonGroup, ToggleButton, Tooltip, Typography } from '@mui/material';
+import { DataType } from '~/utils/internal_types';
+
+interface DataTypeToggleProps {
+  columnId: string;
+  value: DataType | null;
+  isEditable: boolean;
+  inferredLabel: string | null;
+  onChange: (columnId: string, newDataType: 'Categorical' | 'Continuous' | null) => void;
+}
+
+function DataTypeToggle({
+  columnId,
+  value,
+  isEditable,
+  inferredLabel,
+  onChange,
+}: DataTypeToggleProps) {
+  if (isEditable) {
+    return (
+      <ToggleButtonGroup
+        data-cy={`${columnId}-column-annotation-card-data-type`}
+        value={value}
+        onChange={(_, newDataType) => onChange(columnId, newDataType)}
+        exclusive
+        color="primary"
+        size="small"
+        className="shadow-sm w-full flex h-10"
+      >
+        <Tooltip title="Categorical" arrow>
+          <ToggleButton
+            data-cy={`${columnId}-column-annotation-card-data-type-categorical-button`}
+            value={DataType.categorical}
+            className="px-2 flex-1 w-1/2"
+          >
+            <span className="text-xs font-semibold">Cat.</span>
+          </ToggleButton>
+        </Tooltip>
+
+        <Tooltip title="Continuous" arrow>
+          <ToggleButton
+            data-cy={`${columnId}-column-annotation-card-data-type-continuous-button`}
+            value={DataType.continuous}
+            className="px-2 flex-1 w-1/2"
+          >
+            <span className="text-xs font-semibold">Cont.</span>
+          </ToggleButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+    );
+  }
+
+  return (
+    <Tooltip
+      title={
+        'Data type is automatically determined by standardized variable selection. \n' +
+        ' To change the data type manually, remove the standardized variable'
+      }
+      arrow
+    >
+      <div
+        className="h-10 px-2 flex items-center justify-center border rounded border-gray-200 bg-gray-50/50 text-gray-500 cursor-not-allowed w-full shadow-sm"
+        data-cy={`${columnId}-column-annotation-card-data-type`}
+        tabIndex={0}
+        role="button"
+      >
+        <Typography variant="caption" className="font-medium truncate">
+          {inferredLabel || value || 'Unknown'}
+        </Typography>
+        <HelpIcon sx={{ fontSize: 14 }} className="text-gray-400 ml-1" />
+      </div>
+    </Tooltip>
+  );
+}
+
+export default DataTypeToggle;


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #414

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Extracted the data type toggle button logic from `ColumnAnnotationCard` into a new reusable `DataTypeToggle` component.
- Reduced repetition and improved readability and maintainability of the column annotation UI.
- Added component tests to ensure correct rendering, interaction, and locked/inferred label behavior.

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Extract the column data type selection UI into a reusable DataTypeToggle component and integrate it into the column annotation flow.

Enhancements:
- Introduce a standalone DataTypeToggle component to encapsulate column data type selection and inferred/locked display logic.
- Simplify ColumnAnnotationCard by delegating data type rendering and interaction to the new reusable component.

Tests:
- Add Cypress component tests for DataTypeToggle covering rendering, toggle interaction, and inferred label display when the data type is locked.