### PR TITLE
Feat: Implement auto-hide toggle for annotated columns (#429)

### DIFF
--- a/cypress/component/ColumnAnnotation.cy.tsx
+++ b/cypress/component/ColumnAnnotation.cy.tsx
@@ -46,8 +46,37 @@ describe('ColumnAnnotation', () => {
     });
   });
 
+  // --- NEW TEST FOR ISSUE #429 ---
+  it('filters columns based on visibility toggle (annotated/unannotated/all)', () => {
+    cy.mount(<ColumnAnnotation />);
+
+    // 1. Verify Default State ('unannotated')
+    // Col 2 is unannotated. Cols 1, 3, 4 are annotated.
+    cy.get('p').contains('1 columns remaining | 3 columns annotated').should('be.visible');
+    cy.get('[data-cy="2-column-annotation-card"]').should('be.visible');
+    cy.get('[data-cy="1-column-annotation-card"]').should('not.exist');
+    cy.get('[data-cy="3-column-annotation-card"]').should('not.exist');
+    cy.get('[data-cy="4-column-annotation-card"]').should('not.exist');
+
+    // 2. Switch to 'annotated'
+    cy.get('[aria-label="show annotated only"]').click();
+    cy.get('[data-cy="1-column-annotation-card"]').should('be.visible');
+    cy.get('[data-cy="3-column-annotation-card"]').should('exist');
+    cy.get('[data-cy="4-column-annotation-card"]').should('exist');
+    cy.get('[data-cy="2-column-annotation-card"]').should('not.exist');
+
+    // 3. Switch to 'all'
+    cy.get('[aria-label="show all columns"]').click();
+    cy.get('[data-cy="1-column-annotation-card"]').should('be.visible');
+    cy.get('[data-cy="2-column-annotation-card"]').should('exist');
+    cy.get('[data-cy="3-column-annotation-card"]').should('exist');
+    cy.get('[data-cy="4-column-annotation-card"]').should('exist');
+  });
+
   it('renders the component correctly', () => {
     cy.mount(<ColumnAnnotation />);
+    cy.get('[aria-label="show all columns"]').click(); // Show all for legacy test compatibility
+
     cy.get('[data-cy="column-annotation-container"]').should('be.visible');
     cy.get('[data-cy="1-column-annotation-card"]').should('be.visible');
     cy.get('[data-cy="1-description"] textarea')
@@ -74,6 +103,8 @@ describe('ColumnAnnotation', () => {
 
   it('allows scrolling to access all column cards', () => {
     cy.mount(<ColumnAnnotation />);
+    cy.get('[aria-label="show all columns"]').click(); // Show all for legacy test compatibility
+
     cy.get('[data-cy="scrollable-container"]').should('be.visible');
 
     // Initially visible cards
@@ -89,11 +120,14 @@ describe('ColumnAnnotation', () => {
     cy.get('[data-cy="scrollable-container"]').scrollTo('top');
     cy.get('[data-cy="1-column-annotation-card"]').should('be.visible');
   });
+
   it('edits the description', () => {
     cy.spy(useDataStore.getState().actions, 'userUpdatesColumnDescription').as(
       'userUpdatesColumnDescription'
     );
     cy.mount(<ColumnAnnotation />);
+    cy.get('[aria-label="show all columns"]').click(); // Show all for legacy test compatibility
+
     cy.get('[data-cy="1-description"] textarea')
       .first()
       .as('descriptionTextarea')
@@ -102,8 +136,10 @@ describe('ColumnAnnotation', () => {
     cy.get('@descriptionTextarea').type('new description');
     cy.get('@userUpdatesColumnDescription').should('have.been.calledWith', '1', 'new description');
   });
+
   it('toggles the data type between categorical and continuous', () => {
     cy.mount(<ColumnAnnotation />);
+    cy.get('[aria-label="show all columns"]').click(); // Show all for legacy test compatibility
 
     cy.get('[data-cy="1-column-annotation-card-data-type-categorical-button"]').should(
       'have.class',
@@ -128,6 +164,7 @@ describe('ColumnAnnotation', () => {
 
   it('filters columns based on search input', () => {
     cy.mount(<ColumnAnnotation />);
+    cy.get('[aria-label="show all columns"]').click(); // Show all for legacy test compatibility
 
     cy.get('[data-cy="search-filter-input"]').should('be.visible');
     cy.get('[data-cy="search-filter-counter"]').should('contain', 'Showing 4 of 4 columns');
@@ -158,6 +195,7 @@ describe('ColumnAnnotation', () => {
       'userUpdatesColumnDescription'
     );
     cy.mount(<ColumnAnnotation />);
+    cy.get('[aria-label="show all columns"]').click(); // Show all for legacy test compatibility
 
     cy.get('[data-cy="search-filter-input"]').type('another');
     cy.get('[data-cy="search-filter-counter"]').should('contain', '1 of 4');

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -1,10 +1,14 @@
-import { Box } from '@mui/material';
+import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { useState } from 'react';
 import { useColumns, useDataActions, useStandardizedVariables } from '~/stores/data';
 import { useStandardizedVariableOptions } from '../hooks/useStandardizedVariableOptions';
 import { ColumnAnnotationInstructions } from '../utils/instructions';
 import { DataType } from '../utils/internal_types';
 import ColumnAnnotationCard from './ColumnAnnotationCard';
 import Instruction from './Instruction';
+
+// Defined filter type for Issue #429
+type VisibilityFilter = 'unannotated' | 'annotated' | 'all';
 
 function ColumnAnnotation() {
   const columns = useColumns();
@@ -15,6 +19,18 @@ function ColumnAnnotation() {
     userUpdatesColumnDataType,
   } = useDataActions();
   const standardizedVariableOptions = useStandardizedVariableOptions();
+
+  // --- UI States ---
+  const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>('unannotated');
+
+  const handleFilterChange = (
+    _: React.MouseEvent<HTMLElement>,
+    newFilter: VisibilityFilter | null
+  ) => {
+    if (newFilter !== null) {
+      setVisibilityFilter(newFilter);
+    }
+  };
 
   const columnsArray = Object.entries(columns);
 
@@ -37,10 +53,8 @@ function ColumnAnnotation() {
     userUpdatesColumnDataType(columnId, dataType);
   };
 
+  // Base mapped data
   const columnCardData = columnsArray.map(([columnId, column]) => {
-    // Data type is editable when:
-    // 1. No standardized variable is selected, OR
-    // 2. The selected standardized variable is a multi-column measure
     const selectedStandardizedVariable = column.standardizedVariable
       ? standardizedVariables[column.standardizedVariable]
       : undefined;
@@ -63,17 +77,69 @@ function ColumnAnnotation() {
     };
   });
 
+  // Calculate metrics for Issue #429
+  const totalColumns = columnCardData.length;
+  const annotatedCount = columnCardData.filter((col) => col.standardizedVariableId !== null).length;
+  const remainingCount = totalColumns - annotatedCount;
+
+  // Filter logic for Issue #429
+  const filteredColumnCardData = columnCardData.filter((data) => {
+    const isAnnotated = data.standardizedVariableId !== null;
+    if (visibilityFilter === 'unannotated') return !isAnnotated;
+    if (visibilityFilter === 'annotated') return isAnnotated;
+    return true; // 'all'
+  });
+
   return (
     <div
       className="flex flex-col items-center gap-6 h-[70vh] overflow-hidden"
       data-cy="column-annotation-container"
     >
       <div className="w-full max-w-6xl flex flex-col h-full">
-        <div className="p-4 flex-shrink-0">
-          <Instruction title="Column Annotation" className="mb-0">
-            <ColumnAnnotationInstructions />
-          </Instruction>
+        {/* HEADER SECTION */}
+        <div className="p-4 flex-shrink-0 flex flex-row justify-between items-start gap-4">
+          <div className="flex-1">
+            <Instruction title="Column Annotation" className="mb-0">
+              <ColumnAnnotationInstructions />
+            </Instruction>
+          </div>
         </div>
+
+        {/* --- START: VISIBILITY TOGGLE (Issue #429) --- */}
+        <Box className="flex flex-row justify-between items-center px-4 mb-2">
+          <Typography variant="body2" className="text-gray-600 font-medium">
+            <strong>{remainingCount}</strong> columns remaining | <strong>{annotatedCount}</strong>{' '}
+            columns annotated
+          </Typography>
+
+          <ToggleButtonGroup
+            value={visibilityFilter}
+            exclusive
+            onChange={handleFilterChange}
+            aria-label="column visibility filter"
+            size="small"
+            className="bg-white"
+          >
+            <ToggleButton
+              value="unannotated"
+              aria-label="show unannotated only"
+              className="text-xs px-3"
+            >
+              Unannotated Only
+            </ToggleButton>
+            <ToggleButton
+              value="annotated"
+              aria-label="show annotated only"
+              className="text-xs px-3"
+            >
+              Annotated Only
+            </ToggleButton>
+            <ToggleButton value="all" aria-label="show all columns" className="text-xs px-3">
+              Show All
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+        {/* --- END: VISIBILITY TOGGLE --- */}
 
         <div className="flex-1 overflow-y-auto px-4 pb-4" data-cy="scrollable-container">
           {/* Global Header Row - Sticky */}
@@ -90,23 +156,29 @@ function ColumnAnnotation() {
           </Box>
 
           <div className="space-y-3">
-            {columnCardData.map((columnData) => (
-              <div key={columnData.columnId} className="w-full">
-                <ColumnAnnotationCard
-                  id={columnData.columnId}
-                  name={columnData.name}
-                  description={columnData.description}
-                  dataType={columnData.dataType}
-                  standardizedVariableId={columnData.standardizedVariableId}
-                  standardizedVariableOptions={standardizedVariableOptions}
-                  isDataTypeEditable={columnData.isDataTypeEditable}
-                  inferredDataTypeLabel={columnData.inferredDataTypeLabel}
-                  onDescriptionChange={userUpdatesColumnDescription}
-                  onDataTypeChange={handleDataTypeChange}
-                  onStandardizedVariableChange={handleStandardizedVariableChange}
-                />
-              </div>
-            ))}
+            {filteredColumnCardData.length > 0 ? (
+              filteredColumnCardData.map((columnData) => (
+                <div key={columnData.columnId} className="w-full">
+                  <ColumnAnnotationCard
+                    id={columnData.columnId}
+                    name={columnData.name}
+                    description={columnData.description}
+                    dataType={columnData.dataType}
+                    standardizedVariableId={columnData.standardizedVariableId}
+                    standardizedVariableOptions={standardizedVariableOptions}
+                    isDataTypeEditable={columnData.isDataTypeEditable}
+                    inferredDataTypeLabel={columnData.inferredDataTypeLabel}
+                    onDescriptionChange={userUpdatesColumnDescription}
+                    onDataTypeChange={handleDataTypeChange}
+                    onStandardizedVariableChange={handleStandardizedVariableChange}
+                  />
+                </div>
+              ))
+            ) : (
+              <Box className="text-center py-8 text-gray-500 italic">
+                No columns match the current filter.
+              </Box>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -1,4 +1,5 @@
-import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { Box, ToggleButton, ToggleButtonGroup, Typography, Chip } from '@mui/material';
 import { useState } from 'react';
 import { useColumns, useDataActions, useStandardizedVariables } from '~/stores/data';
 import { useStandardizedVariableOptions } from '../hooks/useStandardizedVariableOptions';
@@ -158,7 +159,21 @@ function ColumnAnnotation() {
           <div className="space-y-3">
             {filteredColumnCardData.length > 0 ? (
               filteredColumnCardData.map((columnData) => (
-                <div key={columnData.columnId} className="w-full">
+                <div key={columnData.columnId} className="w-full relative">
+                  {/* --- START: VISUAL MARKER (Issue #429) --- */}
+                  {columnData.standardizedVariableId !== null && (
+                    <Box className="absolute -top-3 left-4 z-20">
+                      <Chip
+                        icon={<CheckCircleIcon fontSize="small" />}
+                        label="Annotated"
+                        color="success"
+                        size="small"
+                        variant="filled"
+                        className="shadow-sm"
+                      />
+                    </Box>
+                  )}
+                  {/* --- END: VISUAL MARKER --- */}
                   <ColumnAnnotationCard
                     id={columnData.columnId}
                     name={columnData.name}

--- a/src/components/SideColumnNavBar.tsx
+++ b/src/components/SideColumnNavBar.tsx
@@ -1,4 +1,13 @@
-import { List, Paper, ListItem } from '@mui/material';
+import {
+  List,
+  Paper,
+  ListItem,
+  Box,
+  Typography,
+  ToggleButtonGroup,
+  ToggleButton,
+} from '@mui/material';
+import { useState } from 'react';
 import type { UnannotatedColumnGroup } from '~/hooks/useValueAnnotationColumns';
 import type {
   ValueAnnotationNavAnnotatedGroup,
@@ -71,39 +80,93 @@ function SideColumnNavBar({
   onSelect,
   selectedColumnId,
 }: SideColumnNavBarProps) {
+  const [visibilityFilter, setVisibilityFilter] = useState<'unannotated' | 'annotated' | 'all'>(
+    'unannotated'
+  );
+
+  const handleFilterChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newFilter: 'unannotated' | 'annotated' | 'all' | null
+  ) => {
+    if (newFilter !== null) {
+      setVisibilityFilter(newFilter);
+    }
+  };
+
+  // Calculate counts based on groups
+  const annotatedCount = annotatedGroups.length;
+  const remainingCount = unannotatedGroups.length;
+
   return (
     <Paper
-      className="w-full max-w-80 p-4 overflow-y-auto"
+      className="w-full max-w-80 p-4 flex flex-col max-h-full"
       elevation={3}
       data-cy="side-column-nav-bar"
     >
-      <ExpandableSection title="annotated">
-        <List>
-          {annotatedGroups.map((group) => (
-            <ListItem key={group.standardizedVariableId} sx={{ paddingLeft: 2 }}>
-              <AnnotatedColumnGroupCollapse
-                group={group}
-                selectedColumnId={selectedColumnId}
-                onSelect={onSelect}
-              />
-            </ListItem>
-          ))}
-        </List>
-      </ExpandableSection>
+      <Box className="flex flex-col mb-4 shrink-0">
+        <Typography variant="body2" color="text.secondary" className="mb-2 font-medium">
+          {remainingCount} groups remaining | {annotatedCount} annotated
+        </Typography>
+        <ToggleButtonGroup
+          color="primary"
+          value={visibilityFilter}
+          exclusive
+          onChange={handleFilterChange}
+          aria-label="Visibility Filter"
+          size="small"
+          className="w-full bg-white"
+        >
+          <ToggleButton value="unannotated" className="flex-1 text-xs font-semibold py-1">
+            Unannotated
+          </ToggleButton>
+          <ToggleButton value="annotated" className="flex-1 text-xs font-semibold py-1">
+            Annotated
+          </ToggleButton>
+          <ToggleButton value="all" className="flex-1 text-xs font-semibold py-1">
+            Show All
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
 
-      <ExpandableSection title="unannotated" defaultExpanded={false}>
-        <List>
-          {unannotatedGroups.map((group) => (
-            <ListItem key={`unannotated-${group.key}`} sx={{ paddingLeft: 2 }}>
-              <UnannotatedColumnGroupCollapse
-                group={group}
-                onSelect={onSelect}
-                selectedColumnId={selectedColumnId}
-              />
-            </ListItem>
-          ))}
-        </List>
-      </ExpandableSection>
+      <div className="overflow-y-auto flex-1">
+        {(visibilityFilter === 'annotated' || visibilityFilter === 'all') && (
+          <ExpandableSection
+            title="annotated"
+            defaultExpanded={visibilityFilter === 'annotated' || visibilityFilter === 'all'}
+          >
+            <List>
+              {annotatedGroups.map((group) => (
+                <ListItem key={group.standardizedVariableId} sx={{ paddingLeft: 2 }}>
+                  <AnnotatedColumnGroupCollapse
+                    group={group}
+                    selectedColumnId={selectedColumnId}
+                    onSelect={onSelect}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </ExpandableSection>
+        )}
+
+        {(visibilityFilter === 'unannotated' || visibilityFilter === 'all') && (
+          <ExpandableSection
+            title="unannotated"
+            defaultExpanded={visibilityFilter === 'unannotated' || visibilityFilter === 'all'}
+          >
+            <List>
+              {unannotatedGroups.map((group) => (
+                <ListItem key={`unannotated-${group.key}`} sx={{ paddingLeft: 2 }}>
+                  <UnannotatedColumnGroupCollapse
+                    group={group}
+                    onSelect={onSelect}
+                    selectedColumnId={selectedColumnId}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </ExpandableSection>
+        )}
+      </div>
     </Paper>
   );
 }


### PR DESCRIPTION
- Closes 

Changes proposed in this pull request:

- Implemented a `visibilityFilter` state (`'unannotated' | 'annotated' | 'all'`) in `ColumnAnnotation.tsx`.
- Added a `ToggleButtonGroup` UI control above the columns list to switch views.
- Added a dynamically updating counter: `X columns remaining | Y columns annotated`.
- Integrated filtering logic so mapped columns vanish immediately upon annotation when the default "Unannotated Only" view is active.
- Submitted this working prototype of the implementation plan to facilitate the `phase:design` discussion before extending the logic to the `AssessmentAnnotation` view and adding tests.

## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Add visibility filtering controls and annotation status indicators to the column annotation side panel and main view.

New Features:
- Introduce a visibility filter (unannotated, annotated, all) for column annotation cards and side-column groups.
- Display dynamic counts of remaining and annotated columns in both the side navigation and main annotation view.
- Show a visual "Annotated" marker on annotated column cards.

Tests:
- Add Cypress coverage for the new visibility toggle behavior and update existing tests to work with the default unannotated-only view.