### PR TITLE
Implement keyboard shortcuts for column annotation (Fixes #446)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+
 
 npx lint-staged
 

--- a/src/components/ColumnAnnotationCard.tsx
+++ b/src/components/ColumnAnnotationCard.tsx
@@ -7,7 +7,9 @@ import {
   Tooltip,
   TextField,
 } from '@mui/material';
+import { useState } from 'react';
 import { DataType } from '~/utils/internal_types';
+import { useColumnKeyboardShortcuts } from '../hooks/useColumnKeyboardShortcuts';
 import { StandardizedVariableOption } from '../hooks/useStandardizedVariableOptions';
 import DescriptionEditor from './DescriptionEditor';
 
@@ -42,11 +44,23 @@ function ColumnAnnotationCard({
     standardizedVariableId !== null
       ? standardizedVariableOptions.find((option) => option.id === standardizedVariableId) || null
       : null;
+  const [isFocused, setIsFocused] = useState(false);
+
+  useColumnKeyboardShortcuts({
+    columnId: id,
+    isFocused,
+    isDataTypeEditable,
+    onDataTypeChange,
+  });
 
   return (
     <div
       data-cy={`${id}-column-annotation-card`}
       className="w-full bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200"
+      role="button"
+      tabIndex={0}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
     >
       <div className="w-full bg-gray-50 px-4 py-2 border-b border-gray-200 flex items-center">
         <Typography variant="subtitle2" className="font-bold text-gray-900 truncate" title={name}>

--- a/src/hooks/useColumnKeyboardShortcuts.ts
+++ b/src/hooks/useColumnKeyboardShortcuts.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+
+interface UseColumnKeyboardShortcutsProps {
+  columnId: string;
+  isFocused: boolean;
+  isDataTypeEditable: boolean;
+  onDataTypeChange: (columnId: string, newDataType: 'Categorical' | 'Continuous' | null) => void;
+}
+
+export function useColumnKeyboardShortcuts({
+  columnId,
+  isFocused,
+  isDataTypeEditable,
+  onDataTypeChange,
+}: UseColumnKeyboardShortcutsProps) {
+  useEffect(() => {
+    if (!isFocused || !isDataTypeEditable) {
+      return undefined; // 🔥 explicit return
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+      if (e.key === 'c' || e.key === 'C') {
+        e.preventDefault();
+        onDataTypeChange(columnId, 'Categorical');
+      } else if (e.key === 'n' || e.key === 'N') {
+        e.preventDefault();
+        onDataTypeChange(columnId, 'Continuous');
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+
+        const cards = Array.from(
+          document.querySelectorAll('[data-cy$="-column-annotation-card"]')
+        ) as HTMLElement[];
+
+        const currentIndex = cards.findIndex((card) => card === document.activeElement);
+
+        if (currentIndex !== -1 && currentIndex < cards.length - 1) {
+          cards[currentIndex + 1].focus();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isFocused, isDataTypeEditable, columnId, onDataTypeChange]);
+}

--- a/src/utils/instructions.tsx
+++ b/src/utils/instructions.tsx
@@ -138,6 +138,63 @@ export function ColumnAnnotationInstructions() {
         />
       </ListItem>
       <ListItem sx={{ display: 'list-item' }}>
+        <ListItemText
+          primary={
+            <>
+              <strong>Keyboard shortcuts</strong> for faster annotation:
+              <List dense sx={{ listStyleType: 'circle', pl: 4 }}>
+                <ListItem sx={{ display: 'list-item' }}>
+                  <ListItemText
+                    primary={
+                      <>
+                        <code>C</code> — Select Categorical data type
+                      </>
+                    }
+                  />
+                </ListItem>
+                <ListItem sx={{ display: 'list-item' }}>
+                  <ListItemText
+                    primary={
+                      <>
+                        <code>N</code> — Select Continuous data type
+                      </>
+                    }
+                  />
+                </ListItem>
+                <ListItem sx={{ display: 'list-item' }}>
+                  <ListItemText
+                    primary={
+                      <>
+                        <code>Tab</code> — Move focus to the next field within a column card
+                      </>
+                    }
+                  />
+                </ListItem>
+                <ListItem sx={{ display: 'list-item' }}>
+                  <ListItemText
+                    primary={
+                      <>
+                        <code>Enter</code> — Jump to the next column card
+                      </>
+                    }
+                  />
+                </ListItem>
+                <ListItem sx={{ display: 'list-item' }}>
+                  <ListItemText
+                    primary={
+                      <>
+                        Shortcuts are active only when a column card is focused — click on a card
+                        first to activate them.
+                      </>
+                    }
+                  />
+                </ListItem>
+              </List>
+            </>
+          }
+        />
+      </ListItem>
+      <ListItem sx={{ display: 'list-item' }}>
         <ListItemText primary="When you have reviewed all columns, you can move on to the next step." />
       </ListItem>
     </List>


### PR DESCRIPTION
Closes #446

## Changes proposed in this pull request

- Added a new `useColumnKeyboardShortcuts` custom hook in `src/hooks/useColumnKeyboardShortcuts.ts` that listens for keydown events when a column card is focused
- Press `C` to select Categorical data type
- Press `N` to select Continuous data type  
- Press `Enter` to jump to the next row

- Shortcuts are ignored when the user is typing in an input or textarea field
- Updated `ColumnAnnotationCard.tsx` to use the new hook — each card is now focusable via `tabIndex={0}` and tracks focus state
- Updated the Column Annotation help dialog (`src/utils/instructions.tsx`) to document all available keyboard shortcuts for users

## Screenshot

<img width="1891" height="997" alt="Screenshot 2026-02-25 151200" src="https://github.com/user-attachments/assets/3b7ed03c-8cc8-47c1-9a80-a0f39bc2e6c8" />




## Why this matters

The column annotation workflow previously required mouse clicks for every interaction. For researchers annotating datasets with 20-50+ columns, this becomes slow and repetitive. Keyboard shortcuts make the process significantly faster without changing any existing behaviour.

## Summary by Sourcery

Add keyboard-driven interactions to column annotation cards to speed up annotation and document the available shortcuts.

New Features:
- Add a useColumnKeyboardShortcuts hook to handle keyboard interactions for focused column annotation cards, including setting data types and navigating between cards.

Enhancements:
- Make column annotation cards focusable, track focus state, and expose them as button-like elements to support accessible keyboard interactions.

Documentation:
- Document the new column annotation keyboard shortcuts in the ColumnAnnotationInstructions help content.