### PR TITLE
[ENH] Enable description editing for missing values

### DIFF
--- a/cypress/e2e/MissingValueDescriptionRegression.cy.ts
+++ b/cypress/e2e/MissingValueDescriptionRegression.cy.ts
@@ -7,7 +7,7 @@ describe('Missing Value Description Regression', () => {
     cy.intercept('GET', '**/raw.githubusercontent.com/**', { forceNetworkError: true });
   });
 
-  it('should reset the description for the level when it is marked missing during a debounced save', () => {
+  it('should preserve the description for the level when it is marked missing during a debounced save', () => {
     cy.visit('http://localhost:5173');
     cy.get('[data-cy="next-button"]').click();
 
@@ -37,6 +37,8 @@ describe('Missing Value Description Regression', () => {
     cy.get('[data-cy="2-M-missing-value-yes"]').click();
     cy.tick(501);
     cy.get('[data-cy="2-M-description"]').should('not.contain', 'Saving...');
-    cy.get('[data-cy="2-M-description"] textarea').first().should('have.value', '');
+    cy.get('[data-cy="2-M-description"] textarea')
+      .first()
+      .should('have.value', 'Updated description');
   });
 });

--- a/src/components/Categorical.tsx
+++ b/src/components/Categorical.tsx
@@ -179,7 +179,6 @@ function Categorical({
                   columnID={columnID}
                   levelValue={value}
                   description={levels[value]?.description || ''}
-                  disabled={missingValues.includes(value)}
                   onDescriptionChange={(id, description) => {
                     onUpdateDescription(id, value, description || '');
                   }}

--- a/src/hooks/useGenerateDataDictionary.test.ts
+++ b/src/hooks/useGenerateDataDictionary.test.ts
@@ -86,6 +86,61 @@ describe('useGenerateDataDictionary', () => {
     });
   });
 
+  it('should not include missing values in Annotations.Levels but include them in BIDS Levels', () => {
+    mockedUseColumns.mockReturnValue({
+      '1': {
+        id: '1',
+        name: 'diagnosis',
+        allValues: [],
+        description: 'Diagnosis of participant',
+        dataType: DataType.categorical,
+        levels: {
+          HC: { description: 'Healthy Control', standardizedTerm: 'term:hc' },
+          PD: { description: 'Parkinsons Disease', standardizedTerm: 'term:pd' },
+          UNK: { description: 'Unknown diagnosis', standardizedTerm: '' },
+        },
+        standardizedVariable: 'nb:Diagnosis',
+        missingValues: ['UNK'],
+      },
+    });
+
+    mockedUseStandardizedVariables.mockReturnValue({
+      'nb:Diagnosis': {
+        id: 'nb:Diagnosis',
+        name: 'Diagnosis',
+      },
+    });
+
+    mockedUseStandardizedTerms.mockReturnValue({
+      'term:hc': {
+        id: 'term:hc',
+        label: 'Healthy Control',
+        standardizedVariableId: 'nb:Diagnosis',
+      },
+      'term:pd': {
+        id: 'term:pd',
+        label: 'Parkinsons Disease',
+        standardizedVariableId: 'nb:Diagnosis',
+      },
+    });
+
+    const { result } = renderHook(() => useGenerateDataDictionary());
+    const entry = result.current.diagnosis;
+
+    expect(entry.Levels).toEqual({
+      HC: { Description: 'Healthy Control', TermURL: 'term:hc' },
+      PD: { Description: 'Parkinsons Disease', TermURL: 'term:pd' },
+      UNK: { Description: 'Unknown diagnosis' },
+    });
+
+    expect(entry.Annotations?.Levels).toEqual({
+      HC: { TermURL: 'term:hc', Label: 'Healthy Control' },
+      PD: { TermURL: 'term:pd', Label: 'Parkinsons Disease' },
+    });
+
+    expect(entry.Annotations?.MissingValues).toEqual(['UNK']);
+  });
+
   it('should build dictionary entries for continuous columns with units and formats', () => {
     mockedUseColumns.mockReturnValue({
       '2': {

--- a/src/hooks/useGenerateDataDictionary.ts
+++ b/src/hooks/useGenerateDataDictionary.ts
@@ -43,18 +43,21 @@ const buildColumnLevelsDictionary = (
 
 const buildAnnotationLevelsDictionary = (
   levels: ColumnLevels | null | undefined,
-  standardizedTerms: StandardizedTerms
+  standardizedTerms: StandardizedTerms,
+  missingValues: string[] = []
 ): AnnotationLevels =>
-  Object.entries(levels ?? {}).reduce<AnnotationLevels>((acc, [levelValue, levelData]) => {
-    const term = standardizedTerms[levelData.standardizedTerm];
-    return {
-      ...acc,
-      [levelValue]:
-        term?.id && term.label
-          ? { TermURL: term.id, Label: term.label }
-          : ({} as { TermURL: string; Label: string }),
-    };
-  }, {});
+  Object.entries(levels ?? {})
+    .filter(([levelValue]) => !missingValues.includes(levelValue))
+    .reduce<AnnotationLevels>((acc, [levelValue, levelData]) => {
+      const term = standardizedTerms[levelData.standardizedTerm];
+      return {
+        ...acc,
+        [levelValue]:
+          term?.id && term.label
+            ? { TermURL: term.id, Label: term.label }
+            : ({} as { TermURL: string; Label: string }),
+      };
+    }, {});
 
 export function useGenerateDataDictionary(): DataDictionary {
   const columns = useColumns();
@@ -102,7 +105,8 @@ export function useGenerateDataDictionary(): DataDictionary {
           ) {
             entry.Annotations.Levels = buildAnnotationLevelsDictionary(
               column.levels,
-              standardizedTerms
+              standardizedTerms,
+              column.missingValues
             );
           }
 

--- a/src/hooks/useGenerateDataDictionary.ts
+++ b/src/hooks/useGenerateDataDictionary.ts
@@ -47,6 +47,9 @@ const buildAnnotationLevelsDictionary = (
   missingValues: string[] = []
 ): AnnotationLevels =>
   Object.entries(levels ?? {})
+    // Missing values are excluded from the Annotations.Levels dictionary because they do not
+    // represent valid categorical levels for standardized terminology mapping. Instead, they
+    // are explicitly captured under Annotations.MissingValues as per the BIDS specification.
     .filter(([levelValue]) => !missingValues.includes(levelValue))
     .reduce<AnnotationLevels>((acc, [levelValue, levelData]) => {
       const term = standardizedTerms[levelData.standardizedTerm];

--- a/src/hooks/useGenerateDataDictionary.ts
+++ b/src/hooks/useGenerateDataDictionary.ts
@@ -49,7 +49,7 @@ const buildAnnotationLevelsDictionary = (
   Object.entries(levels ?? {})
     // Missing values are excluded from the Annotations.Levels dictionary because they do not
     // represent valid categorical levels for standardized terminology mapping. Instead, they
-    // are explicitly captured under Annotations.MissingValues as per the BIDS specification.
+    // are included in Annotations.MissingValues.
     .filter(([levelValue]) => !missingValues.includes(levelValue))
     .reduce<AnnotationLevels>((acc, [levelValue, levelData]) => {
       const term = standardizedTerms[levelData.standardizedTerm];

--- a/src/stores/data.test.ts
+++ b/src/stores/data.test.ts
@@ -356,6 +356,7 @@ describe('userUploadsDataDictionaryFile', () => {
       data: [
         ['sub-718211', '28.4', 'M', 'ADHD', 'HC', '80'],
         ['sub-718213', '24.6', 'F', 'ADHD', 'HC', '90'],
+        ['sub-718214', '25.0', 'N/A', 'ADHD', 'HC', '95'],
       ],
     });
 
@@ -1586,7 +1587,7 @@ describe('userUpdatesColumnLevelDescription', () => {
     expect(result.current.columns['0'].levels?.B.description).toBe('');
   });
 
-  it('should ignore updates for missing value levels', async () => {
+  it('should allow updates for missing value levels', async () => {
     const mockTsvFile = new File([mockTsvRaw], 'mock.tsv', {
       type: 'text/tab-separated-values',
     });
@@ -1612,54 +1613,20 @@ describe('userUpdatesColumnLevelDescription', () => {
     });
 
     expect(result.current.columns['0'].missingValues).toEqual(['A']);
-    expect(result.current.columns['0'].levels?.A).toBeUndefined();
-
-    expect(() => {
-      act(() => {
-        result.current.actions.userUpdatesValueDescription('0', 'A', 'Group A');
-      });
-    }).not.toThrow();
-
-    expect(result.current.columns['0'].levels?.A).toBeUndefined();
-  });
-
-  it('should ignore updates when the level entry is absent', async () => {
-    const mockTsvFile = new File([mockTsvRaw], 'mock.tsv', {
-      type: 'text/tab-separated-values',
-    });
-
-    mockedReadFile.mockResolvedValueOnce(mockTsvRaw);
-    mockedParseTsvContent.mockReturnValueOnce({
-      headers: ['category'],
-      data: [['A'], ['B'], ['C']],
-    });
-
-    const { result } = renderHook(() => ({
-      actions: useDataActions(),
-      columns: useColumns(),
-    }));
-
-    await act(async () => {
-      await result.current.actions.userUploadsDataTableFile(mockTsvFile);
+    // the missing value gets a default empty description
+    expect(result.current.columns['0'].levels?.A).toEqual({
+      description: '',
+      standardizedTerm: '',
     });
 
     act(() => {
-      result.current.actions.userUpdatesColumnDataType('0', DataType.categorical);
+      result.current.actions.userUpdatesValueDescription('0', 'A', 'Group A');
     });
 
-    expect(result.current.columns['0'].levels).toBeDefined();
-
-    act(() => {
-      result.current.actions.userUpdatesColumnDataType('0', DataType.continuous);
+    expect(result.current.columns['0'].levels?.A).toEqual({
+      description: 'Group A',
+      standardizedTerm: '',
     });
-
-    expect(result.current.columns['0'].levels).toBeUndefined();
-
-    act(() => {
-      result.current.actions.userUpdatesValueDescription('0', 'C', 'Category C');
-    });
-
-    expect(result.current.columns['0'].levels).toBeUndefined();
   });
 });
 
@@ -1820,7 +1787,7 @@ describe('userUpdatesColumnMissingValues', () => {
     return result;
   };
 
-  it('should add missing values and remove them from levels for categorical columns', async () => {
+  it('should add missing values and clear standardizedTerm from levels for categorical columns', async () => {
     const result = await setupCategoricalColumn();
 
     act(() => {
@@ -1828,17 +1795,23 @@ describe('userUpdatesColumnMissingValues', () => {
     });
 
     expect(result.current.columns['0'].missingValues).toEqual(['A']);
-    expect(result.current.columns['0'].levels?.A).toBeUndefined();
+    expect(result.current.columns['0'].levels?.A).toEqual({
+      description: '',
+      standardizedTerm: '',
+    });
 
     act(() => {
       result.current.actions.userUpdatesColumnMissingValues('0', 'B', true);
     });
 
     expect(result.current.columns['0'].missingValues).toEqual(['A', 'B']);
-    expect(result.current.columns['0'].levels?.B).toBeUndefined();
+    expect(result.current.columns['0'].levels?.B).toEqual({
+      description: '',
+      standardizedTerm: '',
+    });
   });
 
-  it('should remove missing values and reintroduce levels when toggled off', async () => {
+  it('should remove missing values and retain levels when toggled off', async () => {
     const result = await setupCategoricalColumn();
 
     act(() => {

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -339,17 +339,8 @@ const useDataStore = create<DataStore>()((set, get) => ({
       set((state) => ({
         columns: produce(state.columns, (draft) => {
           const column = draft[columnID];
-          // Guard against missing columns or removed levels (e.g., toggled to missing).
-          if (!column?.levels?.[value]) {
-            return;
-          }
 
-          // Skip updates for values currently marked as missing.
-          if (column.missingValues?.includes(value)) {
-            return;
-          }
-
-          column.levels[value].description = description;
+          column.levels![value].description = description;
         }),
       }));
     },
@@ -357,11 +348,7 @@ const useDataStore = create<DataStore>()((set, get) => ({
     userUpdatesValueStandardizedTerm(columnID, value, termId) {
       set((state) => ({
         columns: produce(state.columns, (draft) => {
-          if (!draft[columnID].levels || !draft[columnID].levels[value]) {
-            return;
-          }
-
-          draft[columnID].levels[value].standardizedTerm = termId ?? '';
+          draft[columnID].levels![value].standardizedTerm = termId ?? '';
         }),
       }));
     },
@@ -391,7 +378,11 @@ const useDataStore = create<DataStore>()((set, get) => ({
 
           if (column.dataType === DataType.categorical && column.levels) {
             if (isMissing) {
-              delete column.levels[value];
+              if (column.levels[value]) {
+                column.levels[value].standardizedTerm = '';
+              } else {
+                column.levels[value] = { description: '', standardizedTerm: '' };
+              }
             } else if (!column.levels[value]) {
               column.levels[value] = {
                 description: '',

--- a/src/utils/data-utils.test.ts
+++ b/src/utils/data-utils.test.ts
@@ -344,7 +344,7 @@ describe('buildCategoricalLevels', () => {
     expect(result.B).toEqual({ description: '', standardizedTerm: '' });
   });
 
-  it('should include missing values in levels', () => {
+  it('should include missing values in BIDS levels', () => {
     const result = buildCategoricalLevels({
       column: { allValues: ['A', 'N/A', 'B'], missingValues: ['N/A'] },
       columnData: { Description: '' },

--- a/src/utils/data-utils.test.ts
+++ b/src/utils/data-utils.test.ts
@@ -344,7 +344,7 @@ describe('buildCategoricalLevels', () => {
     expect(result.B).toEqual({ description: '', standardizedTerm: '' });
   });
 
-  it('should exclude missing values from levels', () => {
+  it('should include missing values in levels', () => {
     const result = buildCategoricalLevels({
       column: { allValues: ['A', 'N/A', 'B'], missingValues: ['N/A'] },
       columnData: { Description: '' },
@@ -353,7 +353,7 @@ describe('buildCategoricalLevels', () => {
 
     expect(result.A).toEqual({ description: '', standardizedTerm: '' });
     expect(result.B).toEqual({ description: '', standardizedTerm: '' });
-    expect(result['N/A']).toBeUndefined();
+    expect(result['N/A']).toEqual({ description: '', standardizedTerm: '' });
   });
 
   it('should apply dictionary descriptions only for matching values', () => {
@@ -455,7 +455,7 @@ describe('applyDataDictionaryToColumns', () => {
       '0': {
         id: '0',
         name: 'sex',
-        allValues: ['M', 'F'],
+        allValues: ['M', 'F', 'N/A'],
       },
     };
 
@@ -599,7 +599,38 @@ describe('applyDataDictionaryToColumns', () => {
 
     expect(result['0'].levels?.PD).toBeUndefined();
     expect(result['0'].levels?.HC).toBeUndefined();
-    expect(result['0'].levels?.XYZ).toBeUndefined();
+  });
+
+  it('should ignore dictionary MissingValues that are not present in TSV values', () => {
+    const mockColumns = {
+      '0': {
+        id: '0',
+        name: 'sex',
+        allValues: ['M', 'F'],
+        dataType: DataType.categorical,
+      },
+    };
+
+    const mockDataDict = {
+      sex: {
+        Description: 'Sex of the participant',
+        Annotations: {
+          VariableType: 'Categorical' as const,
+          MissingValues: ['N/A', 'UNKNOWN'],
+        },
+      },
+    };
+
+    const result = applyDataDictionaryToColumns(
+      mockColumns as unknown as Columns,
+      mockDataDict as unknown as DataDictionary,
+      {},
+      {},
+      {}
+    );
+
+    // Should be completely empty since 'N/A' and 'UNKNOWN' are not in ['M', 'F']
+    expect(result['0'].missingValues).toEqual([]);
   });
 
   it('should handle multi-column measures with IsPartOf', () => {
@@ -799,7 +830,7 @@ describe('applyDataDictionaryToColumns', () => {
     expect(result['0'].levels?.good.standardizedTerm).toBe('snomed:1304062007');
     expect(result['0'].levels?.bad.description).toBe('Bad');
     expect(result['0'].levels?.extra).toBeUndefined();
-    expect(result['0'].levels?.['N/A']).toBeUndefined();
+    expect(result['0'].levels?.['N/A']).toEqual({ description: '', standardizedTerm: '' });
     expect(result['0'].missingValues).toEqual(['N/A']);
   });
 
@@ -1051,7 +1082,7 @@ describe('applyDataDictionaryToColumns', () => {
     expect(result['0'].description).toBe('Test description');
   });
 
-  it('should not include missing values in categorical levels', () => {
+  it('should include missing values in categorical levels', () => {
     const mockColumns = {
       '0': {
         id: '0',
@@ -1082,7 +1113,7 @@ describe('applyDataDictionaryToColumns', () => {
 
     expect(result['0'].missingValues).toEqual(['NA']);
     expect(result['0'].levels).toBeDefined();
-    expect(result['0'].levels?.NA).toBeUndefined();
+    expect(result['0'].levels?.NA).toEqual({ description: '', standardizedTerm: '' });
   });
 });
 

--- a/src/utils/data-utils.ts
+++ b/src/utils/data-utils.ts
@@ -243,13 +243,10 @@ export function buildCategoricalLevels({
   columnData,
   standardizedTerms,
 }: BuildCategoricalLevelsOptions): LevelMap {
-  const missingValuesSet = new Set(column.missingValues ?? []);
   const initialLevels: LevelMap = {};
-  Array.from(new Set(column.allValues ?? []))
-    .filter((value) => !missingValuesSet.has(value))
-    .forEach((value) => {
-      initialLevels[value] = { description: '', standardizedTerm: '' };
-    });
+  Array.from(new Set(column.allValues ?? [])).forEach((value) => {
+    initialLevels[value] = { description: '', standardizedTerm: '' };
+  });
 
   const finalLevels: LevelMap = {};
   Object.entries(initialLevels).forEach(([value, level]) => {
@@ -325,7 +322,10 @@ export function applyDataDictionaryToColumns(
     }
 
     if (columnData.Annotations?.MissingValues) {
-      column.missingValues = columnData.Annotations.MissingValues;
+      const uniqueValues = new Set(column.allValues ?? []);
+      column.missingValues = columnData.Annotations.MissingValues.filter((value) =>
+        uniqueValues.has(value)
+      );
     }
 
     let variableType: VariableType | undefined;


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #397 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- filter out non-existent entries the array of missing values from the data dictionary using the data table's unique values array
 - data table is the source of truth
- Update the missing value toggle action in the store to initialize empty level objects instead of deleting the level key entirely
- Remove defensive null-checks for undefined levels from value description and standardized term update actions inside the data store
- Remove the disabled property from the description text input of Categorical component when a value is flagged as missing
- Exclude missing value keys when mapping over categorical levels to generate the Annotations fielld for output data dictionary
- Update mock objects and assertions across the unit and E2E test suites to test for strict value intersection and persistent level existence

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Align handling of categorical missing values across the data store, dictionary generation, and UI to keep level metadata editable and consistently represented.

Bug Fixes:
- Ensure missing value keys from imported data dictionaries are only stored when present in the TSV data.
- Allow descriptions and standardized terms to be updated for levels marked as missing instead of silently ignoring those updates.
- Include missing value levels in categorical level maps while excluding them from annotation-level mappings.

Enhancements:
- Preserve existing level descriptions when toggling values to missing, clearing only standardized terms or initializing empty level objects as needed.
- Generate annotation-level dictionaries that omit missing values from Annotations.Levels while recording them explicitly in Annotations.MissingValues.
- Simplify store logic by removing defensive null checks now that level entries are always present for categorical values and enabling editing of missing-value descriptions in the UI.

Tests:
- Update and extend unit and end-to-end tests to cover inclusion/exclusion rules for missing values, level initialization behavior, and persistence of descriptions when toggling missing states.