### PR TITLE
[ENH] Added version string to navbar

### DIFF
--- a/src/components/AppTitle.tsx
+++ b/src/components/AppTitle.tsx
@@ -19,9 +19,21 @@ function AppTitle({ title, githubUrl, docsUrl }: AppTitleProps) {
       <Toolbar>
         <Box component="img" src={logo} alt="Neurobagel Logo" sx={{ height: 45, width: 'auto' }} />
 
-        <Typography variant="h6" component="h1" sx={{ flexGrow: 1, margin: 1 }}>
-          {title}
-        </Typography>
+        <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+          <Typography variant="h6" component="h1" sx={{ margin: 1 }}>
+            {title}
+          </Typography>
+          <Typography
+            sx={{
+              color: 'text.secondary',
+              fontWeight: 500,
+              fontSize: '0.85rem',
+              fontFamily: 'monospace',
+            }}
+          >
+            v{APP_VERSION || 'beta'}
+          </Typography>
+        </Box>
 
         <Box data-cy="external-links">
           <IconButton

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const APP_VERSION: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react-swc';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import istanbul from 'vite-plugin-istanbul';
+import pkg from './package.json' with { type: 'json' };
 
 const injectAnalytics = () => ({
   name: 'inject-analytics',
@@ -25,6 +26,9 @@ const injectAnalytics = () => ({
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    APP_VERSION: JSON.stringify(pkg.version),
+  },
   // This setting fixes the preview port to the same
   // default as the dev server port.
   // Allows cypress e2e tests to run both on dev and


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #221 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Display the application version in the navigation bar using a build‑time injected version string.

New Features:
- Show the current application version next to the app title in the navbar, defaulting to a beta label when no version is available.

Build:
- Inject the package.json version into the frontend as a global APP_VERSION constant during the Vite build.