### PR TITLE
[ENH] Enable creating dataset description

### DIFF
--- a/cypress/component/DatasetDescriptionForm.cy.tsx
+++ b/cypress/component/DatasetDescriptionForm.cy.tsx
@@ -1,0 +1,87 @@
+import DatasetDescriptionForm from '../../src/components/DatasetDescriptionForm';
+import { useDataStore } from '../../src/stores/data';
+
+describe('DatasetDescriptionForm', () => {
+  beforeEach(() => {
+    useDataStore.getState().actions.reset();
+    cy.mount(<DatasetDescriptionForm />);
+  });
+
+  it('renders the form correctly', () => {
+    cy.get('[data-cy="dataset-description-form"]').should('exist');
+    cy.get('[data-cy="dataset-name-input"]').should('exist');
+  });
+
+  it('validates the Name field', () => {
+    cy.get('[data-cy="dataset-name-input"]').find('input').should('have.value', '');
+    cy.get('[data-cy="dataset-name-input"]').contains('Name is required');
+
+    cy.get('[data-cy="dataset-name-input"]').find('input').type('Test Dataset');
+    cy.get('[data-cy="dataset-name-input"]').should('not.contain', 'Name is required');
+
+    cy.get('[data-cy="dataset-name-input"]').find('input').clear();
+    cy.get('[data-cy="dataset-name-input"]').find('input').type('   ');
+    cy.get('[data-cy="dataset-name-input"]').contains('Name is required');
+  });
+
+  it('validates the RepositoryURL and AccessLink fields', () => {
+    const invalidUrl = 'invalid-url';
+    const validUrl = 'https://example.com';
+
+    cy.get('[data-cy="dataset-repo-input"]').find('input').type(invalidUrl);
+    cy.get('[data-cy="dataset-repo-input"]').contains('Must be a valid HTTP/HTTPS URL');
+    cy.get('[data-cy="dataset-repo-input"]').find('input').clear();
+    cy.get('[data-cy="dataset-repo-input"]').find('input').type(validUrl);
+    cy.get('[data-cy="dataset-repo-input"]').should(
+      'not.contain',
+      'Must be a valid HTTP/HTTPS URL'
+    );
+
+    cy.get('[data-cy="dataset-accesslink-input"]').find('input').type(invalidUrl);
+    cy.get('[data-cy="dataset-accesslink-input"]').contains('Must be a valid HTTP/HTTPS URL');
+    cy.get('[data-cy="dataset-accesslink-input"]').find('input').clear();
+    cy.get('[data-cy="dataset-accesslink-input"]').find('input').type(validUrl);
+    cy.get('[data-cy="dataset-accesslink-input"]').should(
+      'not.contain',
+      'Must be a valid HTTP/HTTPS URL'
+    );
+  });
+
+  it('validates the AccessEmail field', () => {
+    const invalidEmail = 'invalid-email';
+    const validEmail = 'test@example.com';
+
+    cy.get('[data-cy="dataset-accessemail-input"]').find('input').type(invalidEmail);
+    cy.get('[data-cy="dataset-accessemail-input"]').contains('Must be a valid email address');
+
+    cy.get('[data-cy="dataset-accessemail-input"]').find('input').clear();
+    cy.get('[data-cy="dataset-accessemail-input"]').find('input').type(validEmail);
+    cy.get('[data-cy="dataset-accessemail-input"]').should(
+      'not.contain',
+      'Must be a valid email address'
+    );
+  });
+
+  it('handles comma-separated array fields and toggles previews', () => {
+    cy.get('[data-cy="dataset-authors-input"]').find('input').type('Author One, Author Two');
+    cy.get('[data-cy="authors-preview"]').should('contain.text', '["Author One", "Author Two"]');
+
+    cy.get('[data-cy="authors-preview-toggle"]').click();
+    cy.get('[data-cy="authors-preview"]').should('not.exist');
+
+    cy.get('[data-cy="authors-preview-toggle"]').click();
+    cy.get('[data-cy="authors-preview"]').should('exist');
+
+    cy.contains('Reference info').click();
+    cy.get('[data-cy="dataset-references-input"]')
+      .find('input')
+      .type('http://paper.com,  http://repo.com ');
+    cy.get('[data-cy="references-preview"]').should(
+      'contain.text',
+      '["http://paper.com", "http://repo.com"]'
+    );
+
+    cy.get('[data-cy="dataset-keywords-input"]').find('input').type('fmri , neuroimaging');
+    cy.get('[data-cy="keywords-preview"]').should('contain.text', '["fmri", "neuroimaging"]');
+  });
+});

--- a/cypress/component/DatasetDescriptionForm.cy.tsx
+++ b/cypress/component/DatasetDescriptionForm.cy.tsx
@@ -13,14 +13,14 @@ describe('DatasetDescriptionForm', () => {
   });
 
   it('validates the Name field', () => {
-    cy.get('[data-cy="dataset-name-input"]').find('input').should('have.value', '');
+    cy.get('[data-cy="dataset-name-input"] input').should('have.value', '');
     cy.get('[data-cy="dataset-name-input"]').contains('Name is required');
 
-    cy.get('[data-cy="dataset-name-input"]').find('input').type('Test Dataset');
+    cy.get('[data-cy="dataset-name-input"] input').type('Test Dataset');
     cy.get('[data-cy="dataset-name-input"]').should('not.contain', 'Name is required');
 
-    cy.get('[data-cy="dataset-name-input"]').find('input').clear();
-    cy.get('[data-cy="dataset-name-input"]').find('input').type('   ');
+    cy.get('[data-cy="dataset-name-input"] input').clear();
+    cy.get('[data-cy="dataset-name-input"] input').type('   ');
     cy.get('[data-cy="dataset-name-input"]').contains('Name is required');
   });
 
@@ -28,19 +28,19 @@ describe('DatasetDescriptionForm', () => {
     const invalidUrl = 'invalid-url';
     const validUrl = 'https://example.com';
 
-    cy.get('[data-cy="dataset-repo-input"]').find('input').type(invalidUrl);
+    cy.get('[data-cy="dataset-repo-input"] input').type(invalidUrl);
     cy.get('[data-cy="dataset-repo-input"]').contains('Must be a valid HTTP/HTTPS URL');
-    cy.get('[data-cy="dataset-repo-input"]').find('input').clear();
-    cy.get('[data-cy="dataset-repo-input"]').find('input').type(validUrl);
+    cy.get('[data-cy="dataset-repo-input"] input').clear();
+    cy.get('[data-cy="dataset-repo-input"] input').type(validUrl);
     cy.get('[data-cy="dataset-repo-input"]').should(
       'not.contain',
       'Must be a valid HTTP/HTTPS URL'
     );
 
-    cy.get('[data-cy="dataset-accesslink-input"]').find('input').type(invalidUrl);
+    cy.get('[data-cy="dataset-accesslink-input"] input').type(invalidUrl);
     cy.get('[data-cy="dataset-accesslink-input"]').contains('Must be a valid HTTP/HTTPS URL');
-    cy.get('[data-cy="dataset-accesslink-input"]').find('input').clear();
-    cy.get('[data-cy="dataset-accesslink-input"]').find('input').type(validUrl);
+    cy.get('[data-cy="dataset-accesslink-input"] input').clear();
+    cy.get('[data-cy="dataset-accesslink-input"] input').type(validUrl);
     cy.get('[data-cy="dataset-accesslink-input"]').should(
       'not.contain',
       'Must be a valid HTTP/HTTPS URL'
@@ -51,37 +51,31 @@ describe('DatasetDescriptionForm', () => {
     const invalidEmail = 'invalid-email';
     const validEmail = 'test@example.com';
 
-    cy.get('[data-cy="dataset-accessemail-input"]').find('input').type(invalidEmail);
+    cy.get('[data-cy="dataset-accessemail-input"] input').type(invalidEmail);
     cy.get('[data-cy="dataset-accessemail-input"]').contains('Must be a valid email address');
 
-    cy.get('[data-cy="dataset-accessemail-input"]').find('input').clear();
-    cy.get('[data-cy="dataset-accessemail-input"]').find('input').type(validEmail);
+    cy.get('[data-cy="dataset-accessemail-input"] input').clear();
+    cy.get('[data-cy="dataset-accessemail-input"] input').type(validEmail);
     cy.get('[data-cy="dataset-accessemail-input"]').should(
       'not.contain',
       'Must be a valid email address'
     );
   });
 
-  it('handles comma-separated array fields and toggles previews', () => {
-    cy.get('[data-cy="dataset-authors-input"]').find('input').type('Author One, Author Two');
+  it('handles comma-separated array fields and conditionally renders previews', () => {
+    cy.get('[data-cy="dataset-authors-input"] input').type('Author One, Author Two');
     cy.get('[data-cy="authors-preview"]').should('contain.text', '["Author One", "Author Two"]');
 
-    cy.get('[data-cy="authors-preview-toggle"]').click();
-    cy.get('[data-cy="authors-preview"]').should('not.exist');
-
-    cy.get('[data-cy="authors-preview-toggle"]').click();
-    cy.get('[data-cy="authors-preview"]').should('exist');
-
     cy.contains('Reference info').click();
-    cy.get('[data-cy="dataset-references-input"]')
-      .find('input')
-      .type('http://paper.com,  http://repo.com ');
+    cy.get('[data-cy="dataset-references-input"] input').type(
+      'http://paper.com,  http://repo.com '
+    );
     cy.get('[data-cy="references-preview"]').should(
       'contain.text',
       '["http://paper.com", "http://repo.com"]'
     );
 
-    cy.get('[data-cy="dataset-keywords-input"]').find('input').type('fmri , neuroimaging');
+    cy.get('[data-cy="dataset-keywords-input"] input').type('fmri , neuroimaging');
     cy.get('[data-cy="keywords-preview"]').should('contain.text', '["fmri", "neuroimaging"]');
   });
 });

--- a/cypress/e2e/CarriageReturnRegression.cy.ts
+++ b/cypress/e2e/CarriageReturnRegression.cy.ts
@@ -22,6 +22,9 @@ describe('Regression tests', () => {
     // Value Annotation view
     cy.get('[data-cy="next-button"]').click();
 
+    // Dataset Description view
+    cy.get('[data-cy="next-button"]').click();
+
     // Download view
     cy.get('[data-cy="download-datadictionary-button"]').click();
 

--- a/cypress/e2e/CollectionVariableTypeRegression.cy.ts
+++ b/cypress/e2e/CollectionVariableTypeRegression.cy.ts
@@ -23,6 +23,9 @@ describe('Regression tests for collection variable type', () => {
     // Value Annotation view
     cy.get('[data-cy="next-button"]').click();
 
+    // Dataset Description view
+    cy.get('[data-cy="next-button"]').click();
+
     // Download view
     cy.get('[data-cy="download-datadictionary-button"]').click();
 
@@ -43,6 +46,9 @@ describe('Regression tests for collection variable type', () => {
     cy.get('[data-cy="next-button"]').click();
 
     // Value Annotation view
+    cy.get('[data-cy="next-button"]').click();
+
+    // Dataset Description view
     cy.get('[data-cy="next-button"]').click();
 
     // Download view
@@ -72,6 +78,9 @@ describe('Regression tests for collection variable type', () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(5000);
     cy.get('[data-cy="2-N/A-missing-value-yes"]').click();
+    cy.get('[data-cy="next-button"]').click();
+
+    // Dataset Description view
     cy.get('[data-cy="next-button"]').click();
 
     // Download view

--- a/cypress/e2e/LegacyAnnotationToolCompatibility.cy.ts
+++ b/cypress/e2e/LegacyAnnotationToolCompatibility.cy.ts
@@ -129,6 +129,9 @@ describe('Legacy Annotation Tool Compatibility', () => {
 
     cy.get('[data-cy="next-button"]').click();
 
+    // Dataset Description view
+    cy.get('[data-cy="next-button"]').click();
+
     // Download view
     cy.get('[data-cy="complete-annotations-alert"]').should('be.visible');
   });

--- a/cypress/e2e/MainUserFlow.cy.ts
+++ b/cypress/e2e/MainUserFlow.cy.ts
@@ -110,8 +110,7 @@ describe('Main user flow', () => {
 
     // Value Annotation view
     cy.get('[data-cy="back-button"]').should('contain', 'Column Annotation');
-    cy.get('[data-cy="next-button"]').should('contain', 'Download');
-    cy.contains('Value Annotation');
+    cy.get('[data-cy="next-button"]').should('contain', 'Dataset Description');
     cy.get('[data-cy="Value Annotation-step"]').within(() => {
       cy.get('.MuiStepLabel-iconContainer').should('have.class', 'Mui-active');
     });
@@ -142,9 +141,11 @@ describe('Main user flow', () => {
     cy.get('[data-cy="side-column-nav-bar-age-age"]').should('be.visible');
     cy.get('[data-cy="next-button"]').click();
 
-    // Download view
-    cy.get('[data-cy="back-button"]').should('contain', 'Value Annotation');
-    cy.contains('Download');
+    // Dataset Description view
+    cy.get('[data-cy="next-button"]').click();
+
+    // Download
+    cy.get('[data-cy="back-button"]').should('contain', 'Dataset Description');
     cy.get('[data-cy="Download-step"]').within(() => {
       cy.get('.MuiStepLabel-iconContainer').should('have.class', 'Mui-active');
     });
@@ -166,7 +167,7 @@ describe('Main user flow', () => {
       expect(fileContentString).to.contain('"Units":"some cool unit"');
     });
   });
-  it('steps through the different app workflows with a partially annotated data dictionary', () => {
+  it.only('steps through the different app workflows with a partially annotated data dictionary', () => {
     cy.visit('http://localhost:5173');
     cy.get('[data-cy="next-button"]').click();
 
@@ -276,6 +277,9 @@ describe('Main user flow', () => {
     cy.get('[data-cy="5-table-container"]').should('be.visible').and('contain.text', '110');
     cy.get('[data-cy="next-button"]').click();
 
+    // Dataset Description view
+    cy.get('[data-cy="next-button"]').click();
+
     // Download view
     cy.get('[data-cy="complete-annotations-alert"]').should('be.visible');
     cy.get('[data-cy="datadictionary-preview"]')
@@ -346,6 +350,44 @@ describe('Main user flow', () => {
       'have.value',
       'Parkinsonism caused by methanol'
     );
+    cy.get('[data-cy="next-button"]').click();
+
+    // Dataset Description view
+    cy.get('[data-cy="dataset-name-input"]').type('My Awesome Dataset');
+    cy.get('[data-cy="dataset-authors-input"]').type('John Doe, Jane Smith');
+    cy.get('[data-cy="dataset-accesstype-select"]').click();
+    cy.get('li[data-value="registered"]').click();
+    cy.get('[data-cy="dataset-instructions-input"]').type('Just download it');
+    cy.get('[data-cy="dataset-repo-input"]').type('https://github.com/my-repo');
+    cy.get('[data-cy="dataset-accessemail-input"]').type('contact@domain.com');
+    cy.get('[data-cy="dataset-accesslink-input"]').type('https://domain.com/access');
+
+    cy.contains('Reference info').click();
+    cy.get('[data-cy="dataset-references-input"]').type(
+      'https://domain.com/paper, Author et al. (2024)'
+    );
+    cy.get('[data-cy="dataset-keywords-input"]').type('fMRI, neuroimaging, nback');
+
+    cy.get('[data-cy="download-dataset-description-button"]').click();
+
+    const outputDescriptionFileName = `${mockDataDictionaryFileName.split('.')[0]}_dataset_description.json`;
+    const outputDescriptionPath = `cypress/downloads/${outputDescriptionFileName}`;
+    cy.readFile(outputDescriptionPath).then((fileContent) => {
+      expect(fileContent.Name).to.equal('My Awesome Dataset');
+      expect(fileContent.Authors).to.deep.equal(['John Doe', 'Jane Smith']);
+      expect(fileContent.AccessType).to.equal('registered');
+      expect(fileContent.AccessInstructions).to.equal('Just download it');
+      expect(fileContent.RepositoryURL).to.equal('https://github.com/my-repo');
+      expect(fileContent.AccessEmail).to.equal('contact@domain.com');
+      expect(fileContent.AccessLink).to.equal('https://domain.com/access');
+      expect(fileContent.ReferencesAndLinks).to.deep.equal([
+        'https://domain.com/paper',
+        'Author et al. (2024)',
+      ]);
+      expect(fileContent.Keywords).to.deep.equal(['fMRI', 'neuroimaging', 'nback']);
+      expect(fileContent.ParticipantCount).to.be.greaterThan(0);
+    });
+
     cy.get('[data-cy="next-button"]').click();
 
     // Download view

--- a/cypress/e2e/MainUserFlow.cy.ts
+++ b/cypress/e2e/MainUserFlow.cy.ts
@@ -373,6 +373,7 @@ describe('Main user flow', () => {
     // Download view
     cy.get('[data-cy="complete-annotations-alert"]').should('be.visible');
     cy.get('[data-cy="download-datadictionary-button"]').click();
+    cy.get('[data-cy="download-datasetdescription-button"]').click();
 
     const outputDescriptionFileName = `${mockDataDictionaryFileName.split('.')[0]}_dataset_description.json`;
     const outputDescriptionPath = `cypress/downloads/${outputDescriptionFileName}`;

--- a/cypress/e2e/MainUserFlow.cy.ts
+++ b/cypress/e2e/MainUserFlow.cy.ts
@@ -368,7 +368,11 @@ describe('Main user flow', () => {
     );
     cy.get('[data-cy="dataset-keywords-input"]').type('fMRI, neuroimaging, nback');
 
-    cy.get('[data-cy="download-dataset-description-button"]').click();
+    cy.get('[data-cy="next-button"]').click();
+
+    // Download view
+    cy.get('[data-cy="complete-annotations-alert"]').should('be.visible');
+    cy.get('[data-cy="download-datadictionary-button"]').click();
 
     const outputDescriptionFileName = `${mockDataDictionaryFileName.split('.')[0]}_dataset_description.json`;
     const outputDescriptionPath = `cypress/downloads/${outputDescriptionFileName}`;
@@ -387,12 +391,6 @@ describe('Main user flow', () => {
       expect(fileContent.Keywords).to.deep.equal(['fMRI', 'neuroimaging', 'nback']);
       expect(fileContent.ParticipantCount).to.be.greaterThan(0);
     });
-
-    cy.get('[data-cy="next-button"]').click();
-
-    // Download view
-    cy.get('[data-cy="complete-annotations-alert"]').should('be.visible');
-    cy.get('[data-cy="download-datadictionary-button"]').click();
 
     cy.readFile(outputPath).then((fileContent) => {
       expect(fileContent.participant_id.Description).to.equal('A participant ID');

--- a/cypress/e2e/MismatchedLevelsRegression.cy.ts
+++ b/cypress/e2e/MismatchedLevelsRegression.cy.ts
@@ -75,6 +75,9 @@ describe('Mismatched Levels Regression', () => {
     cy.get('[data-cy="1-hc-term-dropdown"] input').should('have.value', 'Healthy Control');
     cy.get('[data-cy="next-button"]').click();
 
+    // Dataset Description view
+    cy.get('[data-cy="next-button"]').click();
+
     // Confirm the preview reflects data table values
     cy.get('[data-cy="datadictionary-preview"]').should('be.visible');
     cy.get('[data-cy="datadictionary-preview"]').should('contain', 'pd');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from '@mui/material/styles';
 import AppTitle from './components/AppTitle';
 import ColumnAnnotation from './components/ColumnAnnotation';
+import DatasetDescription from './components/DatasetDescription';
 import Download from './components/Download';
 import Landing from './components/Landing';
 import NavStepper from './components/NavStepper';
@@ -34,6 +35,8 @@ function App() {
 
       case View.ValueAnnotation:
         return <ValueAnnotation />;
+      case View.DatasetDescription:
+        return <DatasetDescription />;
       case View.Download:
         return <Download />;
       default:

--- a/src/assets/neurobagel_data_dictionary.schema.json
+++ b/src/assets/neurobagel_data_dictionary.schema.json
@@ -204,14 +204,14 @@
         "ValueRange": {
           "description": "The minimum and maximum values of the continuous column",
           "properties": {
-            "MinValue": {
+            "Min": {
               "type": "number"
             },
-            "MaxValue": {
+            "Max": {
               "type": "number"
             }
           },
-          "required": ["MinValue", "MaxValue"],
+          "required": ["Min", "Max"],
           "type": "object"
         },
         "VariableType": {

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -1,5 +1,5 @@
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { Box, Button } from '@mui/material';
+import { Box, Button, Alert, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import {
   useColumns,
@@ -9,6 +9,7 @@ import {
 } from '~/stores/data';
 import useSessionStore from '~/stores/session';
 import { useColumnCardData } from '../hooks/useColumnCardData';
+import { useIsParticipantIDMapped } from '../hooks/useIsParticipantIDMapped';
 import { useMappingMetrics } from '../hooks/useMappingMetrics';
 import { useMultiSelect } from '../hooks/useMultiSelect';
 import { useSearchFilter } from '../hooks/useSearchFilter';
@@ -39,6 +40,7 @@ function ColumnAnnotation() {
   const { setHasSeenColumnAnnotationTour } = useSessionStore();
 
   const columnCardData = useColumnCardData(columns, standardizedVariables, standardizedTerms);
+  const { hasMappedParticipantId, hasMappedOtherColumns } = useIsParticipantIDMapped();
 
   const [hideAnnotated, setHideAnnotated] = useState(false);
 
@@ -133,6 +135,18 @@ function ColumnAnnotation() {
         {/* Main Column Listing - Left Side */}
         <div className="flex-1 flex flex-col min-w-0 py-4">
           <div className="flex-shrink-0 flex flex-col items-start gap-4 mb-4">
+            {hasMappedOtherColumns && !hasMappedParticipantId && (
+              <Alert severity="warning" data-cy="missing-participant-id-warning" className="w-full">
+                <Typography variant="h6" className="mb-2 font-bold">
+                  Missing Participant ID
+                </Typography>
+                <Typography variant="body1">
+                  You have not mapped a <b>Participant ID</b> column. Without a Participant ID, your
+                  dataset description will be incomplete as it cannot calculate the total number of
+                  participants.
+                </Typography>
+              </Alert>
+            )}
             <Button
               variant="outlined"
               startIcon={<InfoOutlinedIcon />}

--- a/src/components/ColumnAnnotation.tsx
+++ b/src/components/ColumnAnnotation.tsx
@@ -1,5 +1,5 @@
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { Box, Button, Alert, Typography } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { useMemo, useState } from 'react';
 import {
   useColumns,
@@ -18,6 +18,7 @@ import { VariableType } from '../utils/internal_types';
 import BulkActionBar from './BulkActionBar';
 import ColumnAnnotationCard from './ColumnAnnotationCard';
 import ColumnAnnotationTour from './ColumnAnnotationTour';
+import MissingParticipantIdAlert from './MissingParticipantIdAlert';
 import SearchFilter from './SearchFilter';
 import StandardizedVariablesList from './StandardizedVariablesList';
 import VirtualColumnList from './VirtualColumnList';
@@ -136,16 +137,7 @@ function ColumnAnnotation() {
         <div className="flex-1 flex flex-col min-w-0 py-4">
           <div className="flex-shrink-0 flex flex-col items-start gap-4 mb-4">
             {hasMappedOtherColumns && !hasMappedParticipantId && (
-              <Alert severity="warning" data-cy="missing-participant-id-warning" className="w-full">
-                <Typography variant="h6" className="mb-2 font-bold">
-                  Missing Participant ID
-                </Typography>
-                <Typography variant="body1">
-                  You have not mapped a <b>Participant ID</b> column. Without a Participant ID, your
-                  dataset description will be incomplete as it cannot calculate the total number of
-                  participants.
-                </Typography>
-              </Alert>
+              <MissingParticipantIdAlert className="w-full" />
             )}
             <Button
               variant="outlined"

--- a/src/components/DatasetDescription.tsx
+++ b/src/components/DatasetDescription.tsx
@@ -1,0 +1,135 @@
+import DownloadIcon from '@mui/icons-material/Download';
+import { Alert, Typography, Button } from '@mui/material';
+import { useMemo } from 'react';
+import { useIsParticipantIDMapped } from '../hooks/useIsParticipantIDMapped';
+import {
+  useDatasetDescription,
+  useColumns,
+  useStandardizedVariables,
+  useUploadedDataTableFileName,
+} from '../stores/data';
+import { isValidUrl, emailRegex } from '../utils/util';
+import DatasetDescriptionForm from './DatasetDescriptionForm';
+
+function DatasetDescription() {
+  const datasetDescription = useDatasetDescription();
+  const columns = useColumns();
+  const standardizedVariables = useStandardizedVariables();
+  const uploadedDataTableFileName = useUploadedDataTableFileName();
+  const { hasMappedParticipantId, hasMappedOtherColumns } = useIsParticipantIDMapped();
+
+  const participantCount = useMemo(() => {
+    let count = 0;
+    const participantColumn = Object.values(columns).find((col) => {
+      const stdVar = col.standardizedVariable
+        ? standardizedVariables[col.standardizedVariable]
+        : null;
+      return stdVar?.name === 'Participant ID';
+    });
+
+    if (participantColumn) {
+      const uniqueIDs = new Set(participantColumn.allValues);
+      count = uniqueIDs.size;
+    }
+    return count;
+  }, [columns, standardizedVariables]);
+
+  const isNameInvalid = datasetDescription.Name.trim() === '';
+  const isRepoUrlInvalid =
+    datasetDescription.RepositoryURL.trim() !== '' &&
+    !isValidUrl(datasetDescription.RepositoryURL.trim());
+  const isAccessEmailInvalid =
+    datasetDescription.AccessEmail.trim() !== '' &&
+    !emailRegex.test(datasetDescription.AccessEmail.trim());
+  const isAccessLinkInvalid =
+    datasetDescription.AccessLink.trim() !== '' &&
+    !isValidUrl(datasetDescription.AccessLink.trim());
+
+  const isFormInvalid =
+    isNameInvalid || isRepoUrlInvalid || isAccessEmailInvalid || isAccessLinkInvalid;
+
+  const handleDownloadDescription = () => {
+    const baseFileName = uploadedDataTableFileName?.slice(0, -4) || 'dataset';
+
+    const finalDatasetDescription: Record<string, string | number | string[]> = {};
+
+    const listFields = ['Authors', 'ReferencesAndLinks', 'Keywords'];
+
+    Object.entries(datasetDescription).forEach(([k, v]) => {
+      if (listFields.includes(k) && typeof v === 'string') {
+        const parsedList = v
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s !== '');
+        if (parsedList.length > 0) {
+          finalDatasetDescription[k] = parsedList;
+        }
+      } else if (Array.isArray(v)) {
+        if (v.length > 0) {
+          finalDatasetDescription[k] = v;
+        }
+      } else if (typeof v === 'string' && v.trim() !== '') {
+        finalDatasetDescription[k] = v.trim();
+      }
+    });
+
+    if (participantCount > 0) {
+      finalDatasetDescription.ParticipantCount = participantCount;
+    }
+
+    const descriptionBlob = new Blob([JSON.stringify(finalDatasetDescription, null, 2)], {
+      type: 'application/json;charset=utf-8',
+    });
+
+    const descriptionUrl = URL.createObjectURL(descriptionBlob);
+    const descriptionA = document.createElement('a');
+    descriptionA.href = descriptionUrl;
+    descriptionA.download = `${baseFileName}_dataset_description.json`;
+    document.body.appendChild(descriptionA);
+    descriptionA.click();
+    URL.revokeObjectURL(descriptionUrl);
+    document.body.removeChild(descriptionA);
+  };
+
+  return (
+    <div className="flex flex-col items-center p-6" data-cy="dataset-description-page">
+      {hasMappedOtherColumns && !hasMappedParticipantId && (
+        <Alert
+          severity="warning"
+          data-cy="missing-participant-id-warning"
+          className="mb-6 w-full max-w-2xl"
+        >
+          <Typography variant="h6" className="mb-2 font-bold">
+            Missing Participant ID
+          </Typography>
+          <Typography variant="body1">
+            You have not mapped a <b>Participant ID</b> column. Without a Participant ID, your
+            dataset description will be incomplete as it cannot calculate the total number of
+            participants.
+          </Typography>
+        </Alert>
+      )}
+
+      <div className="w-full max-w-2xl">
+        <DatasetDescriptionForm />
+      </div>
+
+      <div className="flex w-full flex-col items-center mt-6">
+        <div className="flex gap-4">
+          <Button
+            variant="contained"
+            color="success"
+            endIcon={<DownloadIcon />}
+            onClick={handleDownloadDescription}
+            disabled={isFormInvalid}
+            data-cy="download-dataset-description-button"
+          >
+            Download Dataset Description
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DatasetDescription;

--- a/src/components/DatasetDescription.tsx
+++ b/src/components/DatasetDescription.tsx
@@ -1,132 +1,18 @@
-import DownloadIcon from '@mui/icons-material/Download';
-import { Alert, Typography, Button } from '@mui/material';
-import { useMemo } from 'react';
 import { useIsParticipantIDMapped } from '../hooks/useIsParticipantIDMapped';
-import {
-  useDatasetDescription,
-  useColumns,
-  useStandardizedVariables,
-  useUploadedDataTableFileName,
-} from '../stores/data';
-import { isValidUrl, emailRegex } from '../utils/util';
 import DatasetDescriptionForm from './DatasetDescriptionForm';
+import MissingParticipantIdAlert from './MissingParticipantIdAlert';
 
 function DatasetDescription() {
-  const datasetDescription = useDatasetDescription();
-  const columns = useColumns();
-  const standardizedVariables = useStandardizedVariables();
-  const uploadedDataTableFileName = useUploadedDataTableFileName();
   const { hasMappedParticipantId, hasMappedOtherColumns } = useIsParticipantIDMapped();
-
-  const participantCount = useMemo(() => {
-    let count = 0;
-    const participantColumn = Object.values(columns).find((col) => {
-      const stdVar = col.standardizedVariable
-        ? standardizedVariables[col.standardizedVariable]
-        : null;
-      return stdVar?.name === 'Participant ID';
-    });
-
-    if (participantColumn) {
-      const uniqueIDs = new Set(participantColumn.allValues);
-      count = uniqueIDs.size;
-    }
-    return count;
-  }, [columns, standardizedVariables]);
-
-  const isNameInvalid = datasetDescription.Name.trim() === '';
-  const isRepoUrlInvalid =
-    datasetDescription.RepositoryURL.trim() !== '' &&
-    !isValidUrl(datasetDescription.RepositoryURL.trim());
-  const isAccessEmailInvalid =
-    datasetDescription.AccessEmail.trim() !== '' &&
-    !emailRegex.test(datasetDescription.AccessEmail.trim());
-  const isAccessLinkInvalid =
-    datasetDescription.AccessLink.trim() !== '' &&
-    !isValidUrl(datasetDescription.AccessLink.trim());
-
-  const isFormInvalid =
-    isNameInvalid || isRepoUrlInvalid || isAccessEmailInvalid || isAccessLinkInvalid;
-
-  const handleDownloadDescription = () => {
-    const baseFileName = uploadedDataTableFileName?.slice(0, -4) || 'dataset';
-
-    const finalDatasetDescription: Record<string, string | number | string[]> = {};
-
-    const listFields = ['Authors', 'ReferencesAndLinks', 'Keywords'];
-
-    Object.entries(datasetDescription).forEach(([k, v]) => {
-      if (listFields.includes(k) && typeof v === 'string') {
-        const parsedList = v
-          .split(',')
-          .map((s) => s.trim())
-          .filter((s) => s !== '');
-        if (parsedList.length > 0) {
-          finalDatasetDescription[k] = parsedList;
-        }
-      } else if (Array.isArray(v)) {
-        if (v.length > 0) {
-          finalDatasetDescription[k] = v;
-        }
-      } else if (typeof v === 'string' && v.trim() !== '') {
-        finalDatasetDescription[k] = v.trim();
-      }
-    });
-
-    if (participantCount > 0) {
-      finalDatasetDescription.ParticipantCount = participantCount;
-    }
-
-    const descriptionBlob = new Blob([JSON.stringify(finalDatasetDescription, null, 2)], {
-      type: 'application/json;charset=utf-8',
-    });
-
-    const descriptionUrl = URL.createObjectURL(descriptionBlob);
-    const descriptionA = document.createElement('a');
-    descriptionA.href = descriptionUrl;
-    descriptionA.download = `${baseFileName}_dataset_description.json`;
-    document.body.appendChild(descriptionA);
-    descriptionA.click();
-    URL.revokeObjectURL(descriptionUrl);
-    document.body.removeChild(descriptionA);
-  };
 
   return (
     <div className="flex flex-col items-center p-6" data-cy="dataset-description-page">
       {hasMappedOtherColumns && !hasMappedParticipantId && (
-        <Alert
-          severity="warning"
-          data-cy="missing-participant-id-warning"
-          className="mb-6 w-full max-w-2xl"
-        >
-          <Typography variant="h6" className="mb-2 font-bold">
-            Missing Participant ID
-          </Typography>
-          <Typography variant="body1">
-            You have not mapped a <b>Participant ID</b> column. Without a Participant ID, your
-            dataset description will be incomplete as it cannot calculate the total number of
-            participants.
-          </Typography>
-        </Alert>
+        <MissingParticipantIdAlert className="mb-6 w-full max-w-2xl" />
       )}
 
       <div className="w-full max-w-2xl">
         <DatasetDescriptionForm />
-      </div>
-
-      <div className="flex w-full flex-col items-center mt-6">
-        <div className="flex gap-4">
-          <Button
-            variant="contained"
-            color="success"
-            endIcon={<DownloadIcon />}
-            onClick={handleDownloadDescription}
-            disabled={isFormInvalid}
-            data-cy="download-dataset-description-button"
-          >
-            Download Dataset Description
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/src/components/DatasetDescriptionForm.tsx
+++ b/src/components/DatasetDescriptionForm.tsx
@@ -8,46 +8,40 @@ import {
   AccordionSummary,
   AccordionDetails,
 } from '@mui/material';
-import { useState } from 'react';
+import { useDatasetDescriptionValidation } from '../hooks/useDatasetDescriptionValidation';
 import { useDatasetDescription, useDataActions } from '../stores/data';
 import { DatasetDescriptionFormState } from '../utils/internal_types';
-import { isValidUrl, emailRegex } from '../utils/util';
 
 const ACCESS_TYPES = ['public', 'registered', 'restricted'];
+
+function ArrayPreviewDisplay({ value, dataCy }: { value: string; dataCy: string }) {
+  if (value.trim() === '') return null;
+
+  const arr = value
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v !== '');
+
+  if (arr.length === 0) return null;
+
+  return (
+    <Box className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700" data-cy={dataCy}>
+      {`[${arr.map((item) => JSON.stringify(item)).join(', ')}]`}
+    </Box>
+  );
+}
 
 function DatasetDescriptionForm() {
   const datasetDescription = useDatasetDescription();
   const { userUpdatesDatasetDescription } = useDataActions();
 
-  const [showAuthorsPreview, setShowAuthorsPreview] = useState(true);
-  const [showReferencesPreview, setShowReferencesPreview] = useState(true);
-  const [showKeywordsPreview, setShowKeywordsPreview] = useState(true);
-
-  const parseCommaSeparated = (val: string) =>
-    val
-      .split(',')
-      .map((v) => v.trim())
-      .filter((v) => v !== '');
-
-  const formatArrayPreview = (arr: string[]) =>
-    `[${arr.map((item) => JSON.stringify(item)).join(', ')}]`;
+  const { isNameInvalid, isRepoUrlInvalid, isAccessEmailInvalid, isAccessLinkInvalid } =
+    useDatasetDescriptionValidation();
 
   const handleChange =
     (field: keyof DatasetDescriptionFormState) => (event: React.ChangeEvent<HTMLInputElement>) => {
       userUpdatesDatasetDescription(field, event.target.value);
     };
-
-  // Validation logic
-  const isNameInvalid = datasetDescription.Name.trim() === '';
-  const isRepoUrlInvalid =
-    datasetDescription.RepositoryURL.trim() !== '' &&
-    !isValidUrl(datasetDescription.RepositoryURL.trim());
-  const isAccessEmailInvalid =
-    datasetDescription.AccessEmail.trim() !== '' &&
-    !emailRegex.test(datasetDescription.AccessEmail.trim());
-  const isAccessLinkInvalid =
-    datasetDescription.AccessLink.trim() !== '' &&
-    !isValidUrl(datasetDescription.AccessLink.trim());
 
   return (
     <Box className="flex flex-col gap-4 mb-6 w-full max-w-2xl" data-cy="dataset-description-form">
@@ -78,44 +72,16 @@ function DatasetDescriptionForm() {
           label="Authors"
           value={datasetDescription.Authors as string}
           onChange={handleChange('Authors')}
-          helperText={
-            <Box component="span" className="flex justify-between w-full">
-              <span>Enter a comma-separated list of authors</span>
-              <Box
-                component="button"
-                type="button"
-                onClick={() => setShowAuthorsPreview(!showAuthorsPreview)}
-                sx={{
-                  typography: 'caption',
-                  color: 'primary.main',
-                  cursor: 'pointer',
-                  background: 'none',
-                  border: 'none',
-                  p: 0,
-                  ml: 1,
-                }}
-                data-cy="authors-preview-toggle"
-              >
-                {showAuthorsPreview ? 'Hide Preview' : 'Show Preview'}
-              </Box>
-            </Box>
-          }
-          slotProps={{
-            formHelperText: { component: 'div' } as React.HTMLAttributes<HTMLDivElement>,
-          }}
+          helperText="Enter a comma-separated list of authors"
           fullWidth
           size="small"
           placeholder="e.g. John Doe, Jane Smith"
           data-cy="dataset-authors-input"
         />
-        {showAuthorsPreview && (datasetDescription.Authors as string).trim() !== '' && (
-          <Box
-            className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700"
-            data-cy="authors-preview"
-          >
-            {formatArrayPreview(parseCommaSeparated(datasetDescription.Authors as string))}
-          </Box>
-        )}
+        <ArrayPreviewDisplay
+          value={datasetDescription.Authors as string}
+          dataCy="authors-preview"
+        />
       </Box>
 
       <Box className="flex flex-col gap-2">
@@ -210,91 +176,32 @@ function DatasetDescriptionForm() {
                 label="References and Links"
                 value={datasetDescription.ReferencesAndLinks as string}
                 onChange={handleChange('ReferencesAndLinks')}
-                helperText={
-                  <Box component="span" className="flex justify-between w-full">
-                    <span>Enter a comma-separated list of URLs or citations</span>
-                    <Box
-                      component="button"
-                      type="button"
-                      onClick={() => setShowReferencesPreview(!showReferencesPreview)}
-                      sx={{
-                        typography: 'caption',
-                        color: 'primary.main',
-                        cursor: 'pointer',
-                        background: 'none',
-                        border: 'none',
-                        p: 0,
-                        ml: 1,
-                      }}
-                      data-cy="references-preview-toggle"
-                    >
-                      {showReferencesPreview ? 'Hide Preview' : 'Show Preview'}
-                    </Box>
-                  </Box>
-                }
-                slotProps={{
-                  formHelperText: { component: 'div' } as React.HTMLAttributes<HTMLDivElement>,
-                }}
+                helperText="Enter a comma-separated list of URLs or citations"
                 fullWidth
                 size="small"
                 placeholder="e.g. https://domain.com/paper, Author et al. (2024)"
                 data-cy="dataset-references-input"
               />
-              {showReferencesPreview &&
-                (datasetDescription.ReferencesAndLinks as string).trim() !== '' && (
-                  <Box
-                    className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700"
-                    data-cy="references-preview"
-                  >
-                    {formatArrayPreview(
-                      parseCommaSeparated(datasetDescription.ReferencesAndLinks as string)
-                    )}
-                  </Box>
-                )}
+              <ArrayPreviewDisplay
+                value={datasetDescription.ReferencesAndLinks as string}
+                dataCy="references-preview"
+              />
             </Box>
             <Box className="flex flex-col gap-1">
               <TextField
                 label="Keywords"
                 value={datasetDescription.Keywords as string}
                 onChange={handleChange('Keywords')}
-                helperText={
-                  <Box component="span" className="flex justify-between w-full">
-                    <span>Enter a comma-separated list of keywords</span>
-                    <Box
-                      component="button"
-                      type="button"
-                      onClick={() => setShowKeywordsPreview(!showKeywordsPreview)}
-                      sx={{
-                        typography: 'caption',
-                        color: 'primary.main',
-                        cursor: 'pointer',
-                        background: 'none',
-                        border: 'none',
-                        p: 0,
-                        ml: 1,
-                      }}
-                      data-cy="keywords-preview-toggle"
-                    >
-                      {showKeywordsPreview ? 'Hide Preview' : 'Show Preview'}
-                    </Box>
-                  </Box>
-                }
-                slotProps={{
-                  formHelperText: { component: 'div' } as React.HTMLAttributes<HTMLDivElement>,
-                }}
+                helperText="Enter a comma-separated list of keywords"
                 fullWidth
                 size="small"
                 placeholder="e.g. fMRI, neuroimaging, nback"
                 data-cy="dataset-keywords-input"
               />
-              {showKeywordsPreview && (datasetDescription.Keywords as string).trim() !== '' && (
-                <Box
-                  className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700"
-                  data-cy="keywords-preview"
-                >
-                  {formatArrayPreview(parseCommaSeparated(datasetDescription.Keywords as string))}
-                </Box>
-              )}
+              <ArrayPreviewDisplay
+                value={datasetDescription.Keywords as string}
+                dataCy="keywords-preview"
+              />
             </Box>
           </AccordionDetails>
         </Accordion>

--- a/src/components/DatasetDescriptionForm.tsx
+++ b/src/components/DatasetDescriptionForm.tsx
@@ -1,0 +1,306 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  TextField,
+  MenuItem,
+  Typography,
+  Box,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+import { useState } from 'react';
+import { useDatasetDescription, useDataActions } from '../stores/data';
+import { DatasetDescriptionFormState } from '../utils/internal_types';
+import { isValidUrl, emailRegex } from '../utils/util';
+
+const ACCESS_TYPES = ['public', 'registered', 'restricted'];
+
+function DatasetDescriptionForm() {
+  const datasetDescription = useDatasetDescription();
+  const { userUpdatesDatasetDescription } = useDataActions();
+
+  const [showAuthorsPreview, setShowAuthorsPreview] = useState(true);
+  const [showReferencesPreview, setShowReferencesPreview] = useState(true);
+  const [showKeywordsPreview, setShowKeywordsPreview] = useState(true);
+
+  const parseCommaSeparated = (val: string) =>
+    val
+      .split(',')
+      .map((v) => v.trim())
+      .filter((v) => v !== '');
+
+  const formatArrayPreview = (arr: string[]) =>
+    `[${arr.map((item) => JSON.stringify(item)).join(', ')}]`;
+
+  const handleChange =
+    (field: keyof DatasetDescriptionFormState) => (event: React.ChangeEvent<HTMLInputElement>) => {
+      userUpdatesDatasetDescription(field, event.target.value);
+    };
+
+  // Validation logic
+  const isNameInvalid = datasetDescription.Name.trim() === '';
+  const isRepoUrlInvalid =
+    datasetDescription.RepositoryURL.trim() !== '' &&
+    !isValidUrl(datasetDescription.RepositoryURL.trim());
+  const isAccessEmailInvalid =
+    datasetDescription.AccessEmail.trim() !== '' &&
+    !emailRegex.test(datasetDescription.AccessEmail.trim());
+  const isAccessLinkInvalid =
+    datasetDescription.AccessLink.trim() !== '' &&
+    !isValidUrl(datasetDescription.AccessLink.trim());
+
+  return (
+    <Box className="flex flex-col gap-4 mb-6 w-full max-w-2xl" data-cy="dataset-description-form">
+      <Typography variant="h5" className="font-bold">
+        Dataset Description
+      </Typography>
+      <Typography variant="body2" className="text-gray-600 mb-4">
+        This information is what people will see when they first discover your dataset. Fill out
+        this metadata to generate a Neurobagel-compliant dataset_description.json file.
+      </Typography>
+
+      <TextField
+        autoFocus
+        label="Name"
+        required
+        value={datasetDescription.Name}
+        onChange={handleChange('Name')}
+        error={isNameInvalid}
+        helperText={isNameInvalid ? 'Name is required and cannot be blank' : ''}
+        fullWidth
+        size="small"
+        placeholder="e.g. My Awesome Dataset"
+        data-cy="dataset-name-input"
+      />
+
+      <Box className="flex flex-col gap-1">
+        <TextField
+          label="Authors"
+          value={datasetDescription.Authors as string}
+          onChange={handleChange('Authors')}
+          helperText={
+            <Box component="span" className="flex justify-between w-full">
+              <span>Enter a comma-separated list of authors</span>
+              <Box
+                component="button"
+                type="button"
+                onClick={() => setShowAuthorsPreview(!showAuthorsPreview)}
+                sx={{
+                  typography: 'caption',
+                  color: 'primary.main',
+                  cursor: 'pointer',
+                  background: 'none',
+                  border: 'none',
+                  p: 0,
+                  ml: 1,
+                }}
+                data-cy="authors-preview-toggle"
+              >
+                {showAuthorsPreview ? 'Hide Preview' : 'Show Preview'}
+              </Box>
+            </Box>
+          }
+          slotProps={{
+            formHelperText: { component: 'div' } as React.HTMLAttributes<HTMLDivElement>,
+          }}
+          fullWidth
+          size="small"
+          placeholder="e.g. John Doe, Jane Smith"
+          data-cy="dataset-authors-input"
+        />
+        {showAuthorsPreview && (datasetDescription.Authors as string).trim() !== '' && (
+          <Box
+            className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700"
+            data-cy="authors-preview"
+          >
+            {formatArrayPreview(parseCommaSeparated(datasetDescription.Authors as string))}
+          </Box>
+        )}
+      </Box>
+
+      <Box className="flex flex-col gap-2">
+        <Accordion
+          defaultExpanded
+          variant="outlined"
+          className="shadow-none border border-gray-300"
+        >
+          <AccordionSummary expandIcon={<ExpandMoreIcon />} className="bg-gray-50 min-h-0 h-10">
+            <Typography className="font-medium text-gray-700 text-sm uppercase tracking-wider">
+              Access info
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails className="flex flex-col gap-4 pt-4">
+            <Typography variant="body2" className="text-gray-600">
+              Provide details on how others can access or request this dataset.
+            </Typography>
+            <TextField
+              select
+              label="Access Type"
+              value={datasetDescription.AccessType}
+              onChange={handleChange('AccessType')}
+              fullWidth
+              size="small"
+              data-cy="dataset-accesstype-select"
+            >
+              {ACCESS_TYPES.map((type) => (
+                <MenuItem key={type} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Access Instructions"
+              value={datasetDescription.AccessInstructions}
+              onChange={handleChange('AccessInstructions')}
+              fullWidth
+              size="small"
+              multiline
+              rows={2}
+              placeholder="How to access this dataset"
+              data-cy="dataset-instructions-input"
+            />
+            <TextField
+              label="Repository URL"
+              value={datasetDescription.RepositoryURL}
+              onChange={handleChange('RepositoryURL')}
+              error={isRepoUrlInvalid}
+              helperText={isRepoUrlInvalid ? 'Must be a valid HTTP/HTTPS URL' : ''}
+              fullWidth
+              size="small"
+              placeholder="e.g. https://github.com/my-repo"
+              data-cy="dataset-repo-input"
+            />
+            <TextField
+              label="Access Email"
+              value={datasetDescription.AccessEmail}
+              onChange={handleChange('AccessEmail')}
+              error={isAccessEmailInvalid}
+              helperText={isAccessEmailInvalid ? 'Must be a valid email address' : ''}
+              fullWidth
+              size="small"
+              placeholder="e.g. contact@domain.com"
+              data-cy="dataset-accessemail-input"
+            />
+            <TextField
+              label="Access Link"
+              value={datasetDescription.AccessLink}
+              onChange={handleChange('AccessLink')}
+              error={isAccessLinkInvalid}
+              helperText={isAccessLinkInvalid ? 'Must be a valid HTTP/HTTPS URL' : ''}
+              fullWidth
+              size="small"
+              placeholder="e.g. https://domain.com/access"
+              data-cy="dataset-accesslink-input"
+            />
+          </AccordionDetails>
+        </Accordion>
+
+        <Accordion variant="outlined" className="shadow-none border border-gray-300">
+          <AccordionSummary expandIcon={<ExpandMoreIcon />} className="bg-gray-50 min-h-0 h-10">
+            <Typography className="font-medium text-gray-700 text-sm uppercase tracking-wider">
+              Reference info
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails className="flex flex-col gap-4 pt-4">
+            <Typography variant="body2" className="text-gray-600">
+              Add links, related papers, and keywords to help others evaluate your dataset.
+            </Typography>
+            <Box className="flex flex-col gap-1">
+              <TextField
+                label="References and Links"
+                value={datasetDescription.ReferencesAndLinks as string}
+                onChange={handleChange('ReferencesAndLinks')}
+                helperText={
+                  <Box component="span" className="flex justify-between w-full">
+                    <span>Enter a comma-separated list of URLs or citations</span>
+                    <Box
+                      component="button"
+                      type="button"
+                      onClick={() => setShowReferencesPreview(!showReferencesPreview)}
+                      sx={{
+                        typography: 'caption',
+                        color: 'primary.main',
+                        cursor: 'pointer',
+                        background: 'none',
+                        border: 'none',
+                        p: 0,
+                        ml: 1,
+                      }}
+                      data-cy="references-preview-toggle"
+                    >
+                      {showReferencesPreview ? 'Hide Preview' : 'Show Preview'}
+                    </Box>
+                  </Box>
+                }
+                slotProps={{
+                  formHelperText: { component: 'div' } as React.HTMLAttributes<HTMLDivElement>,
+                }}
+                fullWidth
+                size="small"
+                placeholder="e.g. https://domain.com/paper, Author et al. (2024)"
+                data-cy="dataset-references-input"
+              />
+              {showReferencesPreview &&
+                (datasetDescription.ReferencesAndLinks as string).trim() !== '' && (
+                  <Box
+                    className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700"
+                    data-cy="references-preview"
+                  >
+                    {formatArrayPreview(
+                      parseCommaSeparated(datasetDescription.ReferencesAndLinks as string)
+                    )}
+                  </Box>
+                )}
+            </Box>
+            <Box className="flex flex-col gap-1">
+              <TextField
+                label="Keywords"
+                value={datasetDescription.Keywords as string}
+                onChange={handleChange('Keywords')}
+                helperText={
+                  <Box component="span" className="flex justify-between w-full">
+                    <span>Enter a comma-separated list of keywords</span>
+                    <Box
+                      component="button"
+                      type="button"
+                      onClick={() => setShowKeywordsPreview(!showKeywordsPreview)}
+                      sx={{
+                        typography: 'caption',
+                        color: 'primary.main',
+                        cursor: 'pointer',
+                        background: 'none',
+                        border: 'none',
+                        p: 0,
+                        ml: 1,
+                      }}
+                      data-cy="keywords-preview-toggle"
+                    >
+                      {showKeywordsPreview ? 'Hide Preview' : 'Show Preview'}
+                    </Box>
+                  </Box>
+                }
+                slotProps={{
+                  formHelperText: { component: 'div' } as React.HTMLAttributes<HTMLDivElement>,
+                }}
+                fullWidth
+                size="small"
+                placeholder="e.g. fMRI, neuroimaging, nback"
+                data-cy="dataset-keywords-input"
+              />
+              {showKeywordsPreview && (datasetDescription.Keywords as string).trim() !== '' && (
+                <Box
+                  className="bg-gray-100 p-2 rounded text-xs font-mono text-gray-700"
+                  data-cy="keywords-preview"
+                >
+                  {formatArrayPreview(parseCommaSeparated(datasetDescription.Keywords as string))}
+                </Box>
+              )}
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+    </Box>
+  );
+}
+
+export default DatasetDescriptionForm;

--- a/src/components/DatasetDescriptionForm.tsx
+++ b/src/components/DatasetDescriptionForm.tsx
@@ -8,7 +8,7 @@ import {
   AccordionSummary,
   AccordionDetails,
 } from '@mui/material';
-import { useDatasetDescriptionValidation } from '../hooks/useDatasetDescriptionValidation';
+import { useDatasetDescriptionFormValidation } from '../hooks/useDatasetDescriptionFormValidation';
 import { useDatasetDescription, useDataActions } from '../stores/data';
 import { DatasetDescriptionFormState } from '../utils/internal_types';
 
@@ -35,8 +35,7 @@ function DatasetDescriptionForm() {
   const datasetDescription = useDatasetDescription();
   const { userUpdatesDatasetDescription } = useDataActions();
 
-  const { isNameInvalid, isRepoUrlInvalid, isAccessEmailInvalid, isAccessLinkInvalid } =
-    useDatasetDescriptionValidation();
+  const { datasetDescriptionFormValidation } = useDatasetDescriptionFormValidation();
 
   const handleChange =
     (field: keyof DatasetDescriptionFormState) => (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -59,8 +58,10 @@ function DatasetDescriptionForm() {
         required
         value={datasetDescription.Name}
         onChange={handleChange('Name')}
-        error={isNameInvalid}
-        helperText={isNameInvalid ? 'Name is required and cannot be blank' : ''}
+        error={datasetDescriptionFormValidation.Name}
+        helperText={
+          datasetDescriptionFormValidation.Name ? 'Name is required and cannot be blank' : ''
+        }
         fullWidth
         size="small"
         placeholder="e.g. My Awesome Dataset"
@@ -129,8 +130,12 @@ function DatasetDescriptionForm() {
               label="Repository URL"
               value={datasetDescription.RepositoryURL}
               onChange={handleChange('RepositoryURL')}
-              error={isRepoUrlInvalid}
-              helperText={isRepoUrlInvalid ? 'Must be a valid HTTP/HTTPS URL' : ''}
+              error={datasetDescriptionFormValidation.RepositoryURL}
+              helperText={
+                datasetDescriptionFormValidation.RepositoryURL
+                  ? 'Must be a valid HTTP/HTTPS URL'
+                  : ''
+              }
               fullWidth
               size="small"
               placeholder="e.g. https://github.com/my-repo"
@@ -140,8 +145,10 @@ function DatasetDescriptionForm() {
               label="Access Email"
               value={datasetDescription.AccessEmail}
               onChange={handleChange('AccessEmail')}
-              error={isAccessEmailInvalid}
-              helperText={isAccessEmailInvalid ? 'Must be a valid email address' : ''}
+              error={datasetDescriptionFormValidation.AccessEmail}
+              helperText={
+                datasetDescriptionFormValidation.AccessEmail ? 'Must be a valid email address' : ''
+              }
               fullWidth
               size="small"
               placeholder="e.g. contact@domain.com"
@@ -151,8 +158,10 @@ function DatasetDescriptionForm() {
               label="Access Link"
               value={datasetDescription.AccessLink}
               onChange={handleChange('AccessLink')}
-              error={isAccessLinkInvalid}
-              helperText={isAccessLinkInvalid ? 'Must be a valid HTTP/HTTPS URL' : ''}
+              error={datasetDescriptionFormValidation.AccessLink}
+              helperText={
+                datasetDescriptionFormValidation.AccessLink ? 'Must be a valid HTTP/HTTPS URL' : ''
+              }
               fullWidth
               size="small"
               placeholder="e.g. https://domain.com/access"

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -15,7 +15,9 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import emoji from '../assets/download-emoji.png';
+import { useDatasetDescriptionValidation } from '../hooks/useDatasetDescriptionValidation';
 import { useGenerateDataDictionary } from '../hooks/useGenerateDataDictionary';
+import { useGenerateDatasetDescription } from '../hooks/useGenerateDatasetDescription';
 import { useSchemaValidation } from '../hooks/useSchemaValidation';
 import { useDataActions, useUploadedDataTableFileName, useConfig } from '../stores/data';
 import useViewStore from '../stores/view';
@@ -34,21 +36,41 @@ function Download() {
   const setCurrentView = useViewStore((state) => state.setCurrentView);
 
   const dataDictionary = useGenerateDataDictionary();
+  const datasetDescription = useGenerateDatasetDescription();
+  const { isFormInvalid } = useDatasetDescriptionValidation();
   const { schemaValid, schemaErrors } = useSchemaValidation(dataDictionary);
 
   const handleDownload = () => {
-    const blob = new Blob([JSON.stringify(dataDictionary, null, 2)], {
+    // Download Data Dictionary
+    const dataDictionaryBlob = new Blob([JSON.stringify(dataDictionary, null, 2)], {
       type: 'application/json;charset=utf-8',
     });
 
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${uploadedDataTableFileName?.slice(0, -4)}_annotated.json`;
-    document.body.appendChild(a);
-    a.click();
-    URL.revokeObjectURL(url);
-    document.body.removeChild(a);
+    const dataDictionaryUrl = URL.createObjectURL(dataDictionaryBlob);
+    const dataDictionaryAnchor = document.createElement('a');
+    dataDictionaryAnchor.href = dataDictionaryUrl;
+    dataDictionaryAnchor.download = `${uploadedDataTableFileName?.slice(0, -4)}_annotated.json`;
+    document.body.appendChild(dataDictionaryAnchor);
+    dataDictionaryAnchor.click();
+    URL.revokeObjectURL(dataDictionaryUrl);
+    document.body.removeChild(dataDictionaryAnchor);
+
+    // Download Dataset Description (if valid)
+    if (datasetDescription) {
+      setTimeout(() => {
+        const datasetDescriptionBlob = new Blob([JSON.stringify(datasetDescription, null, 2)], {
+          type: 'application/json;charset=utf-8',
+        });
+        const datasetDescriptionUrl = URL.createObjectURL(datasetDescriptionBlob);
+        const datasetDescriptionAnchor = document.createElement('a');
+        datasetDescriptionAnchor.href = datasetDescriptionUrl;
+        datasetDescriptionAnchor.download = `${uploadedDataTableFileName?.slice(0, -4) || 'dataset'}_dataset_description.json`;
+        document.body.appendChild(datasetDescriptionAnchor);
+        datasetDescriptionAnchor.click();
+        URL.revokeObjectURL(datasetDescriptionUrl);
+        document.body.removeChild(datasetDescriptionAnchor);
+      }, 100);
+    }
   };
 
   const handleAnnotatingNewDataset = () => {
@@ -246,6 +268,19 @@ function Download() {
           />
         ) : null}
 
+        {isFormInvalid && (
+          <Alert
+            severity="info"
+            className="mb-4 w-full max-w-2xl"
+            data-cy="dataset-description-invalid-alert"
+          >
+            <Typography variant="body2">
+              The Dataset Description form is incomplete. Only the Data Dictionary will be
+              downloaded.
+            </Typography>
+          </Alert>
+        )}
+
         <div className="flex gap-4">
           <Button
             data-cy="download-datadictionary-button"
@@ -255,7 +290,7 @@ function Download() {
             onClick={handleDownload}
             endIcon={<DownloadIcon />}
           >
-            Download Data Dictionary
+            {isFormInvalid ? 'Download Data Dictionary' : 'Download All Files'}
           </Button>
         </div>
       </div>

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import emoji from '../assets/download-emoji.png';
-import { useDatasetDescriptionValidation } from '../hooks/useDatasetDescriptionValidation';
+import { useDatasetDescriptionFormValidation } from '../hooks/useDatasetDescriptionFormValidation';
 import { useGenerateDataDictionary } from '../hooks/useGenerateDataDictionary';
 import { useGenerateDatasetDescription } from '../hooks/useGenerateDatasetDescription';
 import { useSchemaValidation } from '../hooks/useSchemaValidation';
@@ -37,11 +37,10 @@ function Download() {
 
   const dataDictionary = useGenerateDataDictionary();
   const datasetDescription = useGenerateDatasetDescription();
-  const { isFormInvalid } = useDatasetDescriptionValidation();
+  const { isFormInvalid } = useDatasetDescriptionFormValidation();
   const { schemaValid, schemaErrors } = useSchemaValidation(dataDictionary);
 
-  const handleDownload = () => {
-    // Download Data Dictionary
+  const handleDownloadDataDictionary = () => {
     const dataDictionaryBlob = new Blob([JSON.stringify(dataDictionary, null, 2)], {
       type: 'application/json;charset=utf-8',
     });
@@ -54,22 +53,21 @@ function Download() {
     dataDictionaryAnchor.click();
     URL.revokeObjectURL(dataDictionaryUrl);
     document.body.removeChild(dataDictionaryAnchor);
+  };
 
-    // Download Dataset Description (if valid)
+  const handleDownloadDatasetDescription = () => {
     if (datasetDescription) {
-      setTimeout(() => {
-        const datasetDescriptionBlob = new Blob([JSON.stringify(datasetDescription, null, 2)], {
-          type: 'application/json;charset=utf-8',
-        });
-        const datasetDescriptionUrl = URL.createObjectURL(datasetDescriptionBlob);
-        const datasetDescriptionAnchor = document.createElement('a');
-        datasetDescriptionAnchor.href = datasetDescriptionUrl;
-        datasetDescriptionAnchor.download = `${uploadedDataTableFileName?.slice(0, -4) || 'dataset'}_dataset_description.json`;
-        document.body.appendChild(datasetDescriptionAnchor);
-        datasetDescriptionAnchor.click();
-        URL.revokeObjectURL(datasetDescriptionUrl);
-        document.body.removeChild(datasetDescriptionAnchor);
-      }, 100);
+      const datasetDescriptionBlob = new Blob([JSON.stringify(datasetDescription, null, 2)], {
+        type: 'application/json;charset=utf-8',
+      });
+      const datasetDescriptionUrl = URL.createObjectURL(datasetDescriptionBlob);
+      const datasetDescriptionAnchor = document.createElement('a');
+      datasetDescriptionAnchor.href = datasetDescriptionUrl;
+      datasetDescriptionAnchor.download = `${uploadedDataTableFileName?.slice(0, -4) || 'dataset'}_dataset_description.json`;
+      document.body.appendChild(datasetDescriptionAnchor);
+      datasetDescriptionAnchor.click();
+      URL.revokeObjectURL(datasetDescriptionUrl);
+      document.body.removeChild(datasetDescriptionAnchor);
     }
   };
 
@@ -275,7 +273,7 @@ function Download() {
             data-cy="dataset-description-invalid-alert"
           >
             <Typography variant="body2">
-              The Dataset Description form is incomplete. Only the Data Dictionary will be
+              The Dataset Description form is incomplete. Only the Data Dictionary can be
               downloaded.
             </Typography>
           </Alert>
@@ -287,11 +285,22 @@ function Download() {
             variant="contained"
             color={schemaValid ? 'success' : 'warning'}
             disabled={!schemaValid && !forceAllowDownload}
-            onClick={handleDownload}
+            onClick={handleDownloadDataDictionary}
             endIcon={<DownloadIcon />}
           >
-            {isFormInvalid ? 'Download Data Dictionary' : 'Download All Files'}
+            Download Data Dictionary
           </Button>
+          {!isFormInvalid && (
+            <Button
+              data-cy="download-datasetdescription-button"
+              variant="contained"
+              color="success"
+              onClick={handleDownloadDatasetDescription}
+              endIcon={<DownloadIcon />}
+            >
+              Download Dataset Description
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/components/MissingParticipantIdAlert.tsx
+++ b/src/components/MissingParticipantIdAlert.tsx
@@ -1,0 +1,19 @@
+import { Alert, Typography } from '@mui/material';
+
+interface MissingParticipantIdAlertProps {
+  className?: string;
+}
+
+export default function MissingParticipantIdAlert({ className }: MissingParticipantIdAlertProps) {
+  return (
+    <Alert severity="warning" data-cy="missing-participant-id-warning" className={className}>
+      <Typography variant="h6" className="mb-2 font-bold">
+        Missing Participant ID
+      </Typography>
+      <Typography variant="body1">
+        You have not mapped a <b>Participant ID</b> column. Without a Participant ID, your dataset
+        description will be incomplete as it cannot calculate the total number of participants.
+      </Typography>
+    </Alert>
+  );
+}

--- a/src/hooks/useDatasetDescriptionFormValidation.test.ts
+++ b/src/hooks/useDatasetDescriptionFormValidation.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDatasetDescription } from '../stores/data';
-import { useDatasetDescriptionValidation } from './useDatasetDescriptionValidation';
+import { useDatasetDescriptionFormValidation } from './useDatasetDescriptionFormValidation';
 
 vi.mock('../stores/data', () => ({
   useDatasetDescription: vi.fn(),
@@ -9,7 +9,7 @@ vi.mock('../stores/data', () => ({
 
 const mockedUseDatasetDescription = vi.mocked(useDatasetDescription);
 
-describe('useDatasetDescriptionValidation', () => {
+describe('useDatasetDescriptionFormValidation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -27,11 +27,11 @@ describe('useDatasetDescriptionValidation', () => {
       AccessLink: '',
     });
 
-    const { result } = renderHook(() => useDatasetDescriptionValidation());
-    expect(result.current.isNameInvalid).toBe(false);
-    expect(result.current.isRepoUrlInvalid).toBe(false);
-    expect(result.current.isAccessEmailInvalid).toBe(false);
-    expect(result.current.isAccessLinkInvalid).toBe(false);
+    const { result } = renderHook(() => useDatasetDescriptionFormValidation());
+    expect(result.current.datasetDescriptionFormValidation.Name).toBe(false);
+    expect(result.current.datasetDescriptionFormValidation.RepositoryURL).toBe(false);
+    expect(result.current.datasetDescriptionFormValidation.AccessEmail).toBe(false);
+    expect(result.current.datasetDescriptionFormValidation.AccessLink).toBe(false);
     expect(result.current.isFormInvalid).toBe(false);
   });
 
@@ -48,8 +48,8 @@ describe('useDatasetDescriptionValidation', () => {
       AccessLink: '',
     });
 
-    const { result } = renderHook(() => useDatasetDescriptionValidation());
-    expect(result.current.isNameInvalid).toBe(true);
+    const { result } = renderHook(() => useDatasetDescriptionFormValidation());
+    expect(result.current.datasetDescriptionFormValidation.Name).toBe(true);
     expect(result.current.isFormInvalid).toBe(true);
   });
 
@@ -66,8 +66,8 @@ describe('useDatasetDescriptionValidation', () => {
       AccessLink: '',
     });
 
-    const { result } = renderHook(() => useDatasetDescriptionValidation());
-    expect(result.current.isRepoUrlInvalid).toBe(true);
+    const { result } = renderHook(() => useDatasetDescriptionFormValidation());
+    expect(result.current.datasetDescriptionFormValidation.RepositoryURL).toBe(true);
     expect(result.current.isFormInvalid).toBe(true);
   });
 
@@ -84,8 +84,8 @@ describe('useDatasetDescriptionValidation', () => {
       AccessLink: '',
     });
 
-    const { result } = renderHook(() => useDatasetDescriptionValidation());
-    expect(result.current.isAccessEmailInvalid).toBe(true);
+    const { result } = renderHook(() => useDatasetDescriptionFormValidation());
+    expect(result.current.datasetDescriptionFormValidation.AccessEmail).toBe(true);
     expect(result.current.isFormInvalid).toBe(true);
   });
 
@@ -102,8 +102,8 @@ describe('useDatasetDescriptionValidation', () => {
       AccessLink: 'not-a-url-either',
     });
 
-    const { result } = renderHook(() => useDatasetDescriptionValidation());
-    expect(result.current.isAccessLinkInvalid).toBe(true);
+    const { result } = renderHook(() => useDatasetDescriptionFormValidation());
+    expect(result.current.datasetDescriptionFormValidation.AccessLink).toBe(true);
     expect(result.current.isFormInvalid).toBe(true);
   });
 
@@ -120,7 +120,7 @@ describe('useDatasetDescriptionValidation', () => {
       AccessLink: 'https://example.com/access',
     });
 
-    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    const { result } = renderHook(() => useDatasetDescriptionFormValidation());
     expect(result.current.isFormInvalid).toBe(false);
   });
 });

--- a/src/hooks/useDatasetDescriptionFormValidation.ts
+++ b/src/hooks/useDatasetDescriptionFormValidation.ts
@@ -1,7 +1,7 @@
 import { useDatasetDescription } from '../stores/data';
 import { isValidUrl, emailRegex } from '../utils/util';
 
-export function useDatasetDescriptionValidation() {
+export function useDatasetDescriptionFormValidation() {
   const datasetDescription = useDatasetDescription();
 
   const isNameInvalid = datasetDescription.Name.trim() === '';
@@ -19,10 +19,12 @@ export function useDatasetDescriptionValidation() {
     isNameInvalid || isRepoUrlInvalid || isAccessEmailInvalid || isAccessLinkInvalid;
 
   return {
-    isNameInvalid,
-    isRepoUrlInvalid,
-    isAccessEmailInvalid,
-    isAccessLinkInvalid,
+    datasetDescriptionFormValidation: {
+      Name: isNameInvalid,
+      RepositoryURL: isRepoUrlInvalid,
+      AccessEmail: isAccessEmailInvalid,
+      AccessLink: isAccessLinkInvalid,
+    },
     isFormInvalid,
   };
 }

--- a/src/hooks/useDatasetDescriptionValidation.test.ts
+++ b/src/hooks/useDatasetDescriptionValidation.test.ts
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDatasetDescription } from '../stores/data';
+import { useDatasetDescriptionValidation } from './useDatasetDescriptionValidation';
+
+vi.mock('../stores/data', () => ({
+  useDatasetDescription: vi.fn(),
+}));
+
+const mockedUseDatasetDescription = vi.mocked(useDatasetDescription);
+
+describe('useDatasetDescriptionValidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return valid when all fields are correct or empty (except Name)', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Valid Name',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: '',
+      AccessEmail: '',
+      AccessLink: '',
+    });
+
+    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    expect(result.current.isNameInvalid).toBe(false);
+    expect(result.current.isRepoUrlInvalid).toBe(false);
+    expect(result.current.isAccessEmailInvalid).toBe(false);
+    expect(result.current.isAccessLinkInvalid).toBe(false);
+    expect(result.current.isFormInvalid).toBe(false);
+  });
+
+  it('should return isNameInvalid=true when Name is empty or whitespace', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: '   ',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: '',
+      AccessEmail: '',
+      AccessLink: '',
+    });
+
+    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    expect(result.current.isNameInvalid).toBe(true);
+    expect(result.current.isFormInvalid).toBe(true);
+  });
+
+  it('should return isRepoUrlInvalid=true when RepositoryURL is an invalid URL', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Test Name',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: 'not-a-url',
+      AccessEmail: '',
+      AccessLink: '',
+    });
+
+    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    expect(result.current.isRepoUrlInvalid).toBe(true);
+    expect(result.current.isFormInvalid).toBe(true);
+  });
+
+  it('should return isAccessEmailInvalid=true when AccessEmail is an invalid email', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Test Name',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: '',
+      AccessEmail: 'invalid-email',
+      AccessLink: '',
+    });
+
+    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    expect(result.current.isAccessEmailInvalid).toBe(true);
+    expect(result.current.isFormInvalid).toBe(true);
+  });
+
+  it('should return isAccessLinkInvalid=true when AccessLink is an invalid URL', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Test Name',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: '',
+      AccessEmail: '',
+      AccessLink: 'not-a-url-either',
+    });
+
+    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    expect(result.current.isAccessLinkInvalid).toBe(true);
+    expect(result.current.isFormInvalid).toBe(true);
+  });
+
+  it('should validate correctly when all fields have valid values', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Test Name',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: 'https://github.com/test',
+      AccessEmail: 'test@example.com',
+      AccessLink: 'https://example.com/access',
+    });
+
+    const { result } = renderHook(() => useDatasetDescriptionValidation());
+    expect(result.current.isFormInvalid).toBe(false);
+  });
+});

--- a/src/hooks/useDatasetDescriptionValidation.ts
+++ b/src/hooks/useDatasetDescriptionValidation.ts
@@ -1,0 +1,28 @@
+import { useDatasetDescription } from '../stores/data';
+import { isValidUrl, emailRegex } from '../utils/util';
+
+export function useDatasetDescriptionValidation() {
+  const datasetDescription = useDatasetDescription();
+
+  const isNameInvalid = datasetDescription.Name.trim() === '';
+  const isRepoUrlInvalid =
+    datasetDescription.RepositoryURL.trim() !== '' &&
+    !isValidUrl(datasetDescription.RepositoryURL.trim());
+  const isAccessEmailInvalid =
+    datasetDescription.AccessEmail.trim() !== '' &&
+    !emailRegex.test(datasetDescription.AccessEmail.trim());
+  const isAccessLinkInvalid =
+    datasetDescription.AccessLink.trim() !== '' &&
+    !isValidUrl(datasetDescription.AccessLink.trim());
+
+  const isFormInvalid =
+    isNameInvalid || isRepoUrlInvalid || isAccessEmailInvalid || isAccessLinkInvalid;
+
+  return {
+    isNameInvalid,
+    isRepoUrlInvalid,
+    isAccessEmailInvalid,
+    isAccessLinkInvalid,
+    isFormInvalid,
+  };
+}

--- a/src/hooks/useGenerateDataDictionary.test.ts
+++ b/src/hooks/useGenerateDataDictionary.test.ts
@@ -306,7 +306,7 @@ describe('useGenerateDataDictionary', () => {
     expect(entry.Annotations?.VariableType).toBe(VariableType.continuous);
   });
 
-  it('should not compute MinValue and MaxValue for age columns if there are any values that fail to parse with the chosen format', () => {
+  it('should not compute Min and Max for age columns if there are any values that fail to parse with the chosen format', () => {
     mockedUseColumns.mockReturnValue({
       '1': {
         id: '1',
@@ -339,7 +339,7 @@ describe('useGenerateDataDictionary', () => {
     expect(entry.Annotations?.ValueRange).toBeUndefined();
   });
 
-  it('should correctly compute MinValue and MaxValue for age columns if all active values parse successfully', () => {
+  it('should correctly compute Min and Max for age columns if all active values parse successfully', () => {
     mockedUseColumns.mockReturnValue({
       '1': {
         id: '1',
@@ -369,8 +369,8 @@ describe('useGenerateDataDictionary', () => {
     const { result } = renderHook(() => useGenerateDataDictionary());
     const entry = result.current.age as DataDictionary[string];
 
-    expect(entry.Annotations?.ValueRange?.MinValue).toBe(20);
-    expect(entry.Annotations?.ValueRange?.MaxValue).toBe(25);
+    expect(entry.Annotations?.ValueRange?.Min).toBe(20);
+    expect(entry.Annotations?.ValueRange?.Max).toBe(25);
   });
   it('should match legacy getDataDictionary output for a fully annotated dataset', () => {
     mockedUseColumns.mockReturnValue({

--- a/src/hooks/useGenerateDataDictionary.ts
+++ b/src/hooks/useGenerateDataDictionary.ts
@@ -149,7 +149,7 @@ export function useGenerateDataDictionary(): DataDictionary {
 
             // If there are any invalid values, the format is considered incorrect
             // for the dataset as a whole (or the user hasn't designated missing values properly).
-            // In this case, we leave MinValue and MaxValue empty ("cannot be computed").
+            // In this case, we leave Min and Max empty ("cannot be computed").
             if (
               validationResult &&
               validationResult.invalidCount === 0 &&
@@ -157,8 +157,8 @@ export function useGenerateDataDictionary(): DataDictionary {
               validationResult.max !== null
             ) {
               entry.Annotations.ValueRange = {
-                MinValue: validationResult.min,
-                MaxValue: validationResult.max,
+                Min: validationResult.min,
+                Max: validationResult.max,
               };
             }
           }

--- a/src/hooks/useGenerateDatasetDescription.test.ts
+++ b/src/hooks/useGenerateDatasetDescription.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useColumns, useDatasetDescription, useStandardizedVariables } from '../stores/data';
+import { DataType, VariableType } from '../utils/internal_types';
+import { useDatasetDescriptionValidation } from './useDatasetDescriptionValidation';
+import { useGenerateDatasetDescription } from './useGenerateDatasetDescription';
+
+vi.mock('../stores/data', () => ({
+  useDatasetDescription: vi.fn(),
+  useColumns: vi.fn(),
+  useStandardizedVariables: vi.fn(),
+}));
+
+vi.mock('./useDatasetDescriptionValidation', () => ({
+  useDatasetDescriptionValidation: vi.fn(),
+}));
+
+const mockedUseDatasetDescription = vi.mocked(useDatasetDescription);
+const mockedUseColumns = vi.mocked(useColumns);
+const mockedUseStandardizedVariables = vi.mocked(useStandardizedVariables);
+const mockedUseDatasetDescriptionValidation = vi.mocked(useDatasetDescriptionValidation);
+
+describe('useGenerateDatasetDescription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseColumns.mockReturnValue({});
+    mockedUseStandardizedVariables.mockReturnValue({});
+    mockedUseDatasetDescriptionValidation.mockReturnValue({
+      isNameInvalid: false,
+      isRepoUrlInvalid: false,
+      isAccessEmailInvalid: false,
+      isAccessLinkInvalid: false,
+      isFormInvalid: false,
+    });
+  });
+
+  it('should return null when the form is invalid', () => {
+    mockedUseDatasetDescriptionValidation.mockReturnValue({
+      isNameInvalid: true,
+      isRepoUrlInvalid: false,
+      isAccessEmailInvalid: false,
+      isAccessLinkInvalid: false,
+      isFormInvalid: true,
+    });
+
+    const { result } = renderHook(() => useGenerateDatasetDescription());
+    expect(result.current).toBeNull();
+  });
+
+  it('should remove empty strings and correctly parse comma-separated lists', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Valid Name',
+      Authors: 'Author A, Author B, ',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: 'link1,link2',
+      Keywords: 'key1, key2',
+      RepositoryURL: '',
+      AccessEmail: '',
+      AccessLink: '',
+    });
+
+    const { result } = renderHook(() => useGenerateDatasetDescription());
+    expect(result.current).toEqual({
+      Name: 'Valid Name',
+      Authors: ['Author A', 'Author B'],
+      ReferencesAndLinks: ['link1', 'link2'],
+      Keywords: ['key1', 'key2'],
+    });
+  });
+
+  it('should calculate ParticipantCount from the Participant ID column', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'Participant Test',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: '',
+      AccessEmail: '',
+      AccessLink: '',
+    });
+
+    mockedUseColumns.mockReturnValue({
+      col1: {
+        id: 'col1',
+        name: 'participant_id',
+        allValues: ['sub-01', 'sub-02', 'sub-01'],
+        dataType: DataType.categorical,
+        standardizedVariable: 'nb:ParticipantID',
+      },
+    });
+
+    mockedUseStandardizedVariables.mockReturnValue({
+      'nb:ParticipantID': {
+        id: 'nb:ParticipantID',
+        name: 'Participant ID',
+        variable_type: VariableType.identifier,
+      },
+    });
+
+    const { result } = renderHook(() => useGenerateDatasetDescription());
+    expect(result.current?.ParticipantCount).toBe(2);
+    expect(result.current?.Name).toBe('Participant Test');
+  });
+
+  it('should not include ParticipantCount if there is no Participant ID column or no participants', () => {
+    mockedUseDatasetDescription.mockReturnValue({
+      Name: 'No Participants',
+      Authors: '',
+      AccessType: '',
+      AccessInstructions: '',
+      ReferencesAndLinks: '',
+      Keywords: '',
+      RepositoryURL: '',
+      AccessEmail: '',
+      AccessLink: '',
+    });
+
+    const { result } = renderHook(() => useGenerateDatasetDescription());
+    expect(result.current?.ParticipantCount).toBeUndefined();
+  });
+});

--- a/src/hooks/useGenerateDatasetDescription.test.ts
+++ b/src/hooks/useGenerateDatasetDescription.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useColumns, useDatasetDescription, useStandardizedVariables } from '../stores/data';
 import { DataType, VariableType } from '../utils/internal_types';
-import { useDatasetDescriptionValidation } from './useDatasetDescriptionValidation';
+import { useDatasetDescriptionFormValidation } from './useDatasetDescriptionFormValidation';
 import { useGenerateDatasetDescription } from './useGenerateDatasetDescription';
 
 vi.mock('../stores/data', () => ({
@@ -11,35 +11,39 @@ vi.mock('../stores/data', () => ({
   useStandardizedVariables: vi.fn(),
 }));
 
-vi.mock('./useDatasetDescriptionValidation', () => ({
-  useDatasetDescriptionValidation: vi.fn(),
+vi.mock('./useDatasetDescriptionFormValidation', () => ({
+  useDatasetDescriptionFormValidation: vi.fn(),
 }));
 
 const mockedUseDatasetDescription = vi.mocked(useDatasetDescription);
 const mockedUseColumns = vi.mocked(useColumns);
 const mockedUseStandardizedVariables = vi.mocked(useStandardizedVariables);
-const mockedUseDatasetDescriptionValidation = vi.mocked(useDatasetDescriptionValidation);
+const mockedUseDatasetDescriptionFormValidation = vi.mocked(useDatasetDescriptionFormValidation);
 
 describe('useGenerateDatasetDescription', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedUseColumns.mockReturnValue({});
     mockedUseStandardizedVariables.mockReturnValue({});
-    mockedUseDatasetDescriptionValidation.mockReturnValue({
-      isNameInvalid: false,
-      isRepoUrlInvalid: false,
-      isAccessEmailInvalid: false,
-      isAccessLinkInvalid: false,
+    mockedUseDatasetDescriptionFormValidation.mockReturnValue({
+      datasetDescriptionFormValidation: {
+        Name: false,
+        RepositoryURL: false,
+        AccessEmail: false,
+        AccessLink: false,
+      },
       isFormInvalid: false,
     });
   });
 
   it('should return null when the form is invalid', () => {
-    mockedUseDatasetDescriptionValidation.mockReturnValue({
-      isNameInvalid: true,
-      isRepoUrlInvalid: false,
-      isAccessEmailInvalid: false,
-      isAccessLinkInvalid: false,
+    mockedUseDatasetDescriptionFormValidation.mockReturnValue({
+      datasetDescriptionFormValidation: {
+        Name: true,
+        RepositoryURL: false,
+        AccessEmail: false,
+        AccessLink: false,
+      },
       isFormInvalid: true,
     });
 

--- a/src/hooks/useGenerateDatasetDescription.ts
+++ b/src/hooks/useGenerateDatasetDescription.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { useDatasetDescription, useColumns, useStandardizedVariables } from '../stores/data';
+import { useDatasetDescriptionValidation } from './useDatasetDescriptionValidation';
+
+export function useGenerateDatasetDescription() {
+  const datasetDescription = useDatasetDescription();
+  const columns = useColumns();
+  const standardizedVariables = useStandardizedVariables();
+  const { isFormInvalid } = useDatasetDescriptionValidation();
+
+  const participantCount = useMemo(() => {
+    let count = 0;
+    const participantColumn = Object.values(columns).find((col) => {
+      const stdVar = col.standardizedVariable
+        ? standardizedVariables[col.standardizedVariable]
+        : null;
+      return stdVar?.name === 'Participant ID';
+    });
+
+    if (participantColumn) {
+      const uniqueIDs = new Set(participantColumn.allValues);
+      count = uniqueIDs.size;
+    }
+    return count;
+  }, [columns, standardizedVariables]);
+
+  const finalDatasetDescription = useMemo(() => {
+    if (isFormInvalid) {
+      return null;
+    }
+
+    const finalDesc: Record<string, string | number | string[]> = {};
+    const listFields = ['Authors', 'ReferencesAndLinks', 'Keywords'];
+
+    Object.entries(datasetDescription).forEach(([k, v]) => {
+      if (listFields.includes(k) && typeof v === 'string') {
+        const parsedList = v
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s !== '');
+        if (parsedList.length > 0) {
+          finalDesc[k] = parsedList;
+        }
+      } else if (Array.isArray(v)) {
+        if (v.length > 0) {
+          finalDesc[k] = v;
+        }
+      } else if (typeof v === 'string' && v.trim() !== '') {
+        finalDesc[k] = v.trim();
+      }
+    });
+
+    if (participantCount > 0) {
+      finalDesc.ParticipantCount = participantCount;
+    }
+
+    return finalDesc;
+  }, [datasetDescription, participantCount, isFormInvalid]);
+
+  return finalDatasetDescription;
+}

--- a/src/hooks/useGenerateDatasetDescription.ts
+++ b/src/hooks/useGenerateDatasetDescription.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import { useDatasetDescription, useColumns, useStandardizedVariables } from '../stores/data';
-import { useDatasetDescriptionValidation } from './useDatasetDescriptionValidation';
+import { useDatasetDescriptionFormValidation } from './useDatasetDescriptionFormValidation';
 
 export function useGenerateDatasetDescription() {
   const datasetDescription = useDatasetDescription();
   const columns = useColumns();
   const standardizedVariables = useStandardizedVariables();
-  const { isFormInvalid } = useDatasetDescriptionValidation();
+  const { isFormInvalid } = useDatasetDescriptionFormValidation();
 
   const participantCount = useMemo(() => {
     let count = 0;

--- a/src/hooks/useIsParticipantIDMapped.test.ts
+++ b/src/hooks/useIsParticipantIDMapped.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as dataStore from '../stores/data';
+import { Column, StandardizedVariable, VariableType } from '../utils/internal_types';
+import { useIsParticipantIDMapped } from './useIsParticipantIDMapped';
+
+vi.mock('../stores/data', () => ({
+  useColumns: vi.fn(),
+  useStandardizedVariables: vi.fn(),
+}));
+
+describe('useIsParticipantIDMapped', () => {
+  it('returns false for both when no columns are mapped', () => {
+    vi.mocked(dataStore.useColumns).mockReturnValue({});
+    vi.mocked(dataStore.useStandardizedVariables).mockReturnValue({});
+
+    const { result } = renderHook(() => useIsParticipantIDMapped());
+    expect(result.current).toEqual({ hasMappedParticipantId: false, hasMappedOtherColumns: false });
+  });
+
+  it('returns true for isParticipantIDMapped and false for hasMappedOtherColumns when only participant ID is mapped', () => {
+    const mockColumns: Record<string, Column> = {
+      col1: {
+        id: 'col1',
+        name: 'col1',
+        description: '',
+        standardizedVariable: 'stdVar1',
+        allValues: [],
+      },
+    };
+
+    const mockStdVars: Record<string, StandardizedVariable> = {
+      stdVar1: {
+        id: 'stdVar1',
+        name: 'Participant ID',
+        description: '',
+        variable_type: VariableType.continuous,
+      },
+    };
+
+    vi.mocked(dataStore.useColumns).mockReturnValue(mockColumns);
+    vi.mocked(dataStore.useStandardizedVariables).mockReturnValue(mockStdVars);
+
+    const { result } = renderHook(() => useIsParticipantIDMapped());
+    expect(result.current).toEqual({ hasMappedParticipantId: true, hasMappedOtherColumns: false });
+  });
+
+  it('returns false for isParticipantIDMapped and true for hasMappedOtherColumns when other columns are mapped but participant ID is not', () => {
+    const mockColumns: Record<string, Column> = {
+      col1: {
+        id: 'col1',
+        name: 'col1',
+        description: '',
+        standardizedVariable: 'stdVar2', // Age
+        allValues: [],
+      },
+    };
+
+    const mockStdVars: Record<string, StandardizedVariable> = {
+      stdVar2: {
+        id: 'stdVar2',
+        name: 'Age',
+        description: '',
+        variable_type: VariableType.continuous,
+      },
+    };
+
+    vi.mocked(dataStore.useColumns).mockReturnValue(mockColumns);
+    vi.mocked(dataStore.useStandardizedVariables).mockReturnValue(mockStdVars);
+
+    const { result } = renderHook(() => useIsParticipantIDMapped());
+    expect(result.current).toEqual({ hasMappedParticipantId: false, hasMappedOtherColumns: true });
+  });
+
+  it('returns true for both when both participant ID and other columns are mapped', () => {
+    const mockColumns: Record<string, Column> = {
+      col1: {
+        id: 'col1',
+        name: 'col1',
+        description: '',
+        standardizedVariable: 'stdVar2', // Age
+        allValues: [],
+      },
+      col2: {
+        id: 'col2',
+        name: 'col2',
+        description: '',
+        standardizedVariable: 'stdVar1', // Participant ID
+        allValues: [],
+      },
+    };
+
+    const mockStdVars: Record<string, StandardizedVariable> = {
+      stdVar1: {
+        id: 'stdVar1',
+        name: 'Participant ID',
+        description: '',
+        variable_type: VariableType.continuous,
+      },
+      stdVar2: {
+        id: 'stdVar2',
+        name: 'Age',
+        description: '',
+        variable_type: VariableType.continuous,
+      },
+    };
+
+    vi.mocked(dataStore.useColumns).mockReturnValue(mockColumns);
+    vi.mocked(dataStore.useStandardizedVariables).mockReturnValue(mockStdVars);
+
+    const { result } = renderHook(() => useIsParticipantIDMapped());
+    expect(result.current).toEqual({ hasMappedParticipantId: true, hasMappedOtherColumns: true });
+  });
+});

--- a/src/hooks/useIsParticipantIDMapped.ts
+++ b/src/hooks/useIsParticipantIDMapped.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { useColumns, useStandardizedVariables } from '../stores/data';
+
+export function useIsParticipantIDMapped(): {
+  hasMappedParticipantId: boolean;
+  hasMappedOtherColumns: boolean;
+} {
+  const columns = useColumns();
+  const standardizedVariables = useStandardizedVariables();
+
+  return useMemo(() => {
+    let hasMappedParticipantId = false;
+    let hasMappedOtherColumns = false;
+
+    Object.values(columns).forEach((col) => {
+      let isParticipantId = false;
+      if (col.standardizedVariable) {
+        const stdVar = standardizedVariables[col.standardizedVariable];
+        if (stdVar?.name === 'Participant ID') {
+          isParticipantId = true;
+        }
+      }
+
+      if (isParticipantId) {
+        hasMappedParticipantId = true;
+      } else if (
+        (col.standardizedVariable !== undefined && col.standardizedVariable !== null) ||
+        (col.isPartOf !== undefined && col.isPartOf !== null)
+      ) {
+        hasMappedOtherColumns = true;
+      }
+    });
+
+    return {
+      hasMappedParticipantId,
+      hasMappedOtherColumns,
+    };
+  }, [columns, standardizedVariables]);
+}

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -33,6 +33,17 @@ const initialState = {
     fileName: '',
     dataDictionary: {},
   },
+  datasetDescription: {
+    Name: '',
+    Authors: '',
+    AccessType: '',
+    AccessInstructions: '',
+    RepositoryURL: '',
+    AccessEmail: '',
+    AccessLink: '',
+    ReferencesAndLinks: '',
+    Keywords: '',
+  },
 };
 
 const useDataStore = create<DataStore>()((set, get) => ({
@@ -433,6 +444,14 @@ const useDataStore = create<DataStore>()((set, get) => ({
       }));
     },
 
+    userUpdatesDatasetDescription(field, value) {
+      set((state) => ({
+        datasetDescription: produce(state.datasetDescription, (draft) => {
+          draft[field] = value;
+        }),
+      }));
+    },
+
     userUpdatesColumnFormat(columnID, formatId) {
       set((state) => ({
         columns: produce(state.columns, (draft) => {
@@ -467,6 +486,7 @@ export const useUploadedDataDictionary = () =>
 export const useIsConfigLoading = () => useDataStore((state) => state.isConfigLoading);
 export const useConfig = () => useDataStore((state) => state.config);
 export const useConfigOptions = () => useDataStore((state) => state.configOptions);
+export const useDatasetDescription = () => useDataStore((state) => state.datasetDescription);
 export const useDataActions = () => useDataStore((state) => state.actions);
 
 // Export the raw store for testing purposes

--- a/src/stores/view.ts
+++ b/src/stores/view.ts
@@ -29,6 +29,7 @@ export const getNavigationProps = (currentView: View): NavigationProps => {
     View.Upload,
     View.ColumnAnnotation,
     View.ValueAnnotation,
+    View.DatasetDescription,
     View.Download,
   ];
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,6 @@
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import DescriptionIcon from '@mui/icons-material/Description';
 import FactCheckIcon from '@mui/icons-material/FactCheck';
 import ViewAgendaIcon from '@mui/icons-material/ViewAgenda';
 import { View, StepConfig } from './internal_types';
@@ -8,6 +9,7 @@ export const steps: StepConfig[] = [
   { label: 'Upload', view: View.Upload, icon: CloudUploadIcon },
   { label: 'Column Annotation', view: View.ColumnAnnotation, icon: ViewAgendaIcon },
   { label: 'Value Annotation', view: View.ValueAnnotation, icon: FactCheckIcon },
+  { label: 'Dataset Description', view: View.DatasetDescription, icon: DescriptionIcon },
   { label: 'Download', view: View.Download, icon: CloudDownloadIcon },
 ];
 

--- a/src/utils/internal_types.ts
+++ b/src/utils/internal_types.ts
@@ -4,12 +4,25 @@ export enum View {
   ColumnAnnotation = 'columnAnnotation',
   MultiColumnMeasures = 'multiColumnMeasures',
   ValueAnnotation = 'valueAnnotation',
+  DatasetDescription = 'datasetDescription',
   Download = 'download',
 }
 
 export interface GlobalMissingValue {
   value: string;
   description?: string;
+}
+
+export interface DatasetDescriptionFormState {
+  Name: string;
+  Authors: string;
+  AccessType: string;
+  AccessInstructions: string;
+  RepositoryURL: string;
+  AccessEmail: string;
+  AccessLink: string;
+  ReferencesAndLinks: string;
+  Keywords: string;
 }
 
 export type StepConfig = {
@@ -123,8 +136,8 @@ export interface DataDictionary {
       };
       MissingValues?: string[];
       ValueRange?: {
-        MinValue: number;
-        MaxValue: number;
+        Min?: number;
+        Max?: number;
       };
     };
   };
@@ -145,6 +158,7 @@ export type DataStoreState = {
   config: string;
   configOptions: string[];
   uploadedDataDictionary: UploadedDataDictionaryFile;
+  datasetDescription: DatasetDescriptionFormState;
 };
 
 export type DataStoreActions = {
@@ -184,6 +198,7 @@ export type DataStoreActions = {
     valuesToApply: { value: string; description?: string }[]
   ) => void;
   userRemovesGlobalMissingStatus: (valueToRemove: string) => void;
+  userUpdatesDatasetDescription: (field: keyof DatasetDescriptionFormState, value: string) => void;
   reset: () => void;
 };
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -13,3 +13,17 @@ export function generateAbbreviation(label: string): string {
   }
   return label;
 }
+
+// URL validation uses the browser's native WHATWG URL parser (the exact same standard rust-url implements)
+export const isValidUrl = (string: string) => {
+  try {
+    const url = new URL(string);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (_) {
+    return false;
+  }
+};
+
+// Email regex corresponds to the HTML5 specification (approximates the RFC 5322 standard used by Pydantic's email-validator)
+export const emailRegex =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #546

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Implemented the Dataset Description form to capture metadata (e.g., Name, Authors, Repository URL) before downloading the dictionary
- Integrated dataset description state management in the store
- Refactored the `ValueRange` schema and data dictionary generator to use `Min` and `Max` keys instead of `MinValue` and `MaxValue`
- Created a `useIsParticipantIDMapped` hook to dynamically track if the Participant ID variable has been assigned to any column
  - Used the hook to display a warning alert to user when they have mapped a column to a var other than participant id
- Implemented native URL and HTML5 email validation utilities to ensure frontend parity with backend Pydantic models
- Updated End-to-End and Component test suites to support the new dataset description workflow step and assert on the updated schema format

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Add a dataset description step to the annotation workflow and align metadata and validation with the updated schema.

New Features:
- Introduce a Dataset Description page and form in the workflow to collect dataset-level metadata and generate a Neurobagel-compliant dataset_description.json file.
- Persist dataset description metadata in the global data store for use during download.
- Add a hook to detect whether a Participant ID has been mapped and surface warnings when it is missing from the dataset.

Enhancements:
- Update the data dictionary schema and generator to use Min and Max keys in ValueRange metadata instead of MinValue and MaxValue.
- Add shared URL and email validation utilities to keep frontend validation consistent with backend models.
- Extend the app navigation and step configuration to include the new Dataset Description step between Value Annotation and Download.

Tests:
- Update end-to-end Cypress workflows to include the Dataset Description step and validate dataset_description.json generation, including participant count and parsed list fields.
- Adjust unit tests for data dictionary generation to cover the new Min and Max ValueRange keys and keep legacy compatibility tests passing.
- Add coverage for Participant ID mapping behavior via the new hook and warnings (test scaffolding present).