### PR TITLE
[ENH] Enable dataset description file Upload to E-PD GDrive

### DIFF
--- a/cypress/component/Download.cy.tsx
+++ b/cypress/component/Download.cy.tsx
@@ -117,6 +117,6 @@ describe('Download', () => {
       );
     cy.get('[data-cy="upload-drive-button"]')
       .should('be.visible')
-      .and('contain', 'Upload Data Dictionary to ENIGMA-PD');
+      .and('contain', 'Upload Dataset Information to ENIGMA-PD');
   });
 });

--- a/cypress/component/Download.cy.tsx
+++ b/cypress/component/Download.cy.tsx
@@ -111,7 +111,10 @@ describe('Download', () => {
 
     cy.get('[data-cy="upload-info-alert"]')
       .should('be.visible')
-      .and('contain', 'Only the data dictionary will be uploaded to the ENIGMA-PD community drive');
+      .and(
+        'contain',
+        'The data dictionary and dataset description (if complete) will be uploaded to the ENIGMA-PD community drive'
+      );
     cy.get('[data-cy="upload-drive-button"]')
       .should('be.visible')
       .and('contain', 'Upload Data Dictionary to ENIGMA-PD');

--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -140,15 +140,6 @@ describe('GoogleDriveUpload', () => {
         ParticipantCount: 42,
       };
 
-      cy.intercept('POST', '**/exec', (req) => {
-        const body = JSON.parse(req.body);
-        if (body.action !== 'getSites') {
-          req.reply({
-            body: { status: 'success', fileId: '12345' },
-          });
-        }
-      }).as('createDualFile');
-
       cy.mount(
         <GoogleDriveUpload
           open={testProps.open}
@@ -161,6 +152,15 @@ describe('GoogleDriveUpload', () => {
       );
 
       cy.wait('@getSites');
+
+      cy.intercept('POST', '**/exec', (req) => {
+        const body = JSON.parse(req.body);
+        if (body.action !== 'getSites') {
+          req.reply({
+            body: { status: 'success', fileId: '12345' },
+          });
+        }
+      }).as('createDualFile');
 
       cy.get('[data-cy="dataset-name-input"]').type('DualFileDataset');
       cy.get('[data-cy="password-input"]').type('correctPass');

--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -126,12 +126,59 @@ describe('GoogleDriveUpload', () => {
         const { body } = interception.request;
         // If body is string (text/plain), parse it. If object, use as is.
         const parsed = typeof body === 'string' ? JSON.parse(body) : body;
-        expect(parsed.filename).to.contain('SuccessDataset');
+        expect(parsed.files[0].filename).to.contain('SuccessDataset');
         expect(parsed.checkExists).to.equal(true);
       });
 
       cy.get('[data-cy="upload-success-alert"]').should('be.visible');
       cy.get('[data-cy="open-drive-file-button"]').should('be.visible');
+    });
+
+    it('should upload dual-files when dataset description is provided', () => {
+      const mockDatasetDescription = {
+        Name: 'Test Dataset',
+        ParticipantCount: 42,
+      };
+
+      cy.intercept('POST', '**/exec', (req) => {
+        const body = JSON.parse(req.body);
+        if (body.action !== 'getSites') {
+          req.reply({
+            body: { status: 'success', fileId: '12345' },
+          });
+        }
+      }).as('createDualFile');
+
+      cy.mount(
+        <GoogleDriveUpload
+          open={testProps.open}
+          onClose={testProps.onClose}
+          dataDictionary={testProps.dataDictionary}
+          datasetDescription={mockDatasetDescription}
+          appsScriptUrl={testProps.appsScriptUrl}
+          config={testProps.config}
+        />
+      );
+
+      cy.wait('@getSites');
+
+      cy.get('[data-cy="dataset-name-input"]').type('DualFileDataset');
+      cy.get('[data-cy="password-input"]').type('correctPass');
+      cy.get('[data-cy="upload-button"]').click();
+
+      cy.wait('@createDualFile').then((interception) => {
+        const { body } = interception.request;
+        const parsed = typeof body === 'string' ? JSON.parse(body) : body;
+
+        expect(parsed.files).to.have.length(2);
+
+        expect(parsed.files[0].filename).to.contain('DualFileDataset.json');
+
+        expect(parsed.files[1].filename).to.contain('DualFileDataset_dataset_description.json');
+        const descriptionContent = JSON.parse(parsed.files[1].content);
+        expect(descriptionContent.Name).to.equal('Test Dataset');
+        expect(descriptionContent.ParticipantCount).to.equal(42);
+      });
     });
 
     it('should handle auth failure', () => {
@@ -188,7 +235,7 @@ describe('GoogleDriveUpload', () => {
         const parsedBody = typeof body === 'string' ? JSON.parse(body) : body;
         expect(parsedBody.checkExists).to.equal(false);
         // Not end without prefix
-        expect(parsedBody.filename).to.not.equal('conflict.json');
+        expect(parsedBody.files[0].filename).to.not.equal('conflict.json');
       });
 
       cy.get('[data-cy="upload-success-alert"]').should('be.visible');
@@ -251,7 +298,7 @@ describe('GoogleDriveUpload', () => {
         const { body } = interception.request;
         const parsedBody = typeof body === 'string' ? JSON.parse(body) : body;
         expect(parsedBody.checkExists).to.equal(false);
-        expect(parsedBody.filename).to.contain('_v2.json');
+        expect(parsedBody.files[0].filename).to.contain('_v2.json');
       });
 
       cy.get('[data-cy="upload-success-alert"]').should('be.visible');

--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -5,6 +5,7 @@ const testProps = {
   open: true,
   onClose: () => {},
   dataDictionary: {},
+  datasetDescription: null,
   appsScriptUrl: 'https://somecoolurl.com/exec',
   config: 'some-config',
 };
@@ -25,6 +26,7 @@ describe('GoogleDriveUpload', () => {
         open={testProps.open}
         onClose={testProps.onClose}
         dataDictionary={testProps.dataDictionary}
+        datasetDescription={testProps.datasetDescription}
         appsScriptUrl={testProps.appsScriptUrl}
         config={testProps.config}
       />
@@ -50,6 +52,7 @@ describe('GoogleDriveUpload', () => {
         open={testProps.open}
         onClose={testProps.onClose}
         dataDictionary={testProps.dataDictionary}
+        datasetDescription={testProps.datasetDescription}
         appsScriptUrl=""
         config={testProps.config}
       />
@@ -73,6 +76,7 @@ describe('GoogleDriveUpload', () => {
           open={testProps.open}
           onClose={testProps.onClose}
           dataDictionary={testProps.dataDictionary}
+          datasetDescription={testProps.datasetDescription}
           appsScriptUrl={testProps.appsScriptUrl}
           config={testProps.config}
         />
@@ -291,6 +295,7 @@ describe('GoogleDriveUpload', () => {
             </button>
             <GoogleDriveUpload
               dataDictionary={testProps.dataDictionary}
+              datasetDescription={testProps.datasetDescription}
               appsScriptUrl={testProps.appsScriptUrl}
               open={open}
               onClose={() => setOpen(false)}

--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -227,7 +227,9 @@ describe('GoogleDriveUpload', () => {
       cy.wait('@createFile');
 
       cy.get('[data-cy="overwrite-confirm-button"]').should('be.visible');
-      cy.get('[data-cy="new-filename-preview"]').should('be.visible').and('contain', 'conflict');
+      cy.get('[data-cy="new-dataset-name-preview"]')
+        .should('be.visible')
+        .and('contain', 'conflict');
 
       cy.get('[data-cy="overwrite-confirm-button"]').click();
       cy.wait('@createFile').then((interception) => {
@@ -262,7 +264,7 @@ describe('GoogleDriveUpload', () => {
 
       cy.wait('@createFileConflict');
 
-      cy.get('[data-cy="new-filename-preview"]').should('contain', '_20260210_120000');
+      cy.get('[data-cy="new-dataset-name-preview"]').should('contain', '_20260210_120000');
     });
 
     it('should use custom suffix when provided', () => {
@@ -291,7 +293,7 @@ describe('GoogleDriveUpload', () => {
       cy.wait('@createFileCustom');
 
       cy.get('[data-cy="custom-suffix-input"]').type('v2');
-      cy.get('[data-cy="new-filename-preview"]').should('contain', '_v2');
+      cy.get('[data-cy="new-dataset-name-preview"]').should('contain', '_v2');
       cy.get('[data-cy="overwrite-confirm-button"]').click();
 
       cy.wait('@createFileCustom').then((interception) => {

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -244,7 +244,7 @@ function Download() {
                 className="mt-4"
                 data-cy="upload-drive-button"
               >
-                Upload Data Dictionary to {config}
+                Upload Dataset Information to {config}
               </Button>
             </div>
             <Divider className="my-6 w-full max-w-2xl" />

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -229,12 +229,10 @@ function Download() {
                 }}
               >
                 <Typography variant="subtitle2">
-                  Only the data dictionary will be uploaded to the ENIGMA-PD community drive
+                  The data dictionary and dataset description (if complete) will be uploaded to the
+                  ENIGMA-PD community drive
                 </Typography>
-                <Typography variant="subtitle2">
-                  Refer to the &quot;Data Dictionary&quot; preview section above to see the exact
-                  content being uploaded.
-                </Typography>
+                <Typography variant="subtitle2">Your tabular data remains local.</Typography>
               </Alert>
 
               <Button
@@ -319,6 +317,7 @@ function Download() {
         open={uploadDialogOpen}
         onClose={() => setUploadDialogOpen(false)}
         dataDictionary={dataDictionary}
+        datasetDescription={datasetDescription}
         config={config}
       />
     </div>

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -18,12 +18,13 @@ import {
   Collapse,
 } from '@mui/material';
 import { useState, useEffect, useCallback } from 'react';
-import { DataDictionary } from '../utils/internal_types';
+import { DataDictionary, DatasetDescription } from '../utils/internal_types';
 
 interface GoogleDriveUploadProps {
   open: boolean;
   onClose: () => void;
   dataDictionary: DataDictionary;
+  datasetDescription: DatasetDescription | null;
   appsScriptUrl?: string;
   config: string;
 }
@@ -49,6 +50,7 @@ const getTimestampSuffix = () =>
 const createUploadPayload = ({
   filename,
   dataDictionary,
+  datasetDescription,
   notes,
   reuploadReason,
   name,
@@ -59,6 +61,7 @@ const createUploadPayload = ({
 }: {
   filename: string;
   dataDictionary: DataDictionary;
+  datasetDescription: DatasetDescription | null;
   notes: string;
   reuploadReason: string;
   name: string;
@@ -67,7 +70,12 @@ const createUploadPayload = ({
   password?: string;
   forceOverwrite: boolean;
 }) => {
-  const fileContent = JSON.stringify(dataDictionary, null, 2);
+  const dataDictionaryContent = JSON.stringify(dataDictionary, null, 2);
+
+  const datasetDescriptionFilename = filename.replace('.json', '_dataset_description.json');
+  const datasetDescriptionContent = datasetDescription
+    ? JSON.stringify(datasetDescription, null, 2)
+    : null;
 
   let commentsContent;
   const hasNotes = notes && notes.trim().length > 0;
@@ -98,13 +106,26 @@ ${notes}`;
   }
 
   return {
-    filename,
-    content: fileContent,
-    description: `Uploaded by ${name} (${email}). Notes: ${notes}`,
     folderName: site,
+    password,
     commentsContent,
     checkExists: !forceOverwrite,
-    password,
+    files: [
+      {
+        filename,
+        content: dataDictionaryContent,
+        description: `Data dictionary uploaded by ${name} (${email}). Notes: ${notes}`,
+      },
+      ...(datasetDescriptionContent
+        ? [
+            {
+              filename: datasetDescriptionFilename,
+              content: datasetDescriptionContent,
+              description: `Dataset description uploaded by ${name} (${email}).`,
+            },
+          ]
+        : []),
+    ],
   };
 };
 
@@ -123,6 +144,7 @@ function GoogleDriveUpload({
   open,
   onClose,
   dataDictionary,
+  datasetDescription,
   appsScriptUrl = import.meta.env.NB_GOOGLE_APPS_SCRIPT_URL,
   config,
 }: GoogleDriveUploadProps) {
@@ -220,6 +242,7 @@ function GoogleDriveUpload({
       const payload = createUploadPayload({
         filename,
         dataDictionary,
+        datasetDescription,
         notes: formData.notes,
         reuploadReason: formData.reuploadReason,
         name: formData.name,
@@ -390,13 +413,13 @@ function GoogleDriveUpload({
             <ul className="list-disc pl-5">
               <li>
                 <Typography variant="body2">
-                  Only the data dictionary (.json) will be uploaded. Your tabular data remains
-                  local.
+                  The data dictionary and dataset description (if complete) will be uploaded. Your
+                  tabular data remains local.
                 </Typography>
               </li>
               <li>
                 <Typography variant="body2">
-                  The file will be uploaded to a private Google Drive folder for the ENIGMA-PD
+                  The files will be uploaded to a private Google Drive folder for the ENIGMA-PD
                   community.
                 </Typography>
               </li>

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -48,7 +48,7 @@ const getTimestampSuffix = () =>
   new Date().toISOString().replace(/[-:]/g, '').replace('T', '_').split('.')[0];
 
 const createUploadPayload = ({
-  filename,
+  datasetName,
   dataDictionary,
   datasetDescription,
   notes,
@@ -59,7 +59,7 @@ const createUploadPayload = ({
   password,
   forceOverwrite,
 }: {
-  filename: string;
+  datasetName: string;
   dataDictionary: DataDictionary;
   datasetDescription: DatasetDescription | null;
   notes: string;
@@ -72,7 +72,7 @@ const createUploadPayload = ({
 }) => {
   const dataDictionaryContent = JSON.stringify(dataDictionary, null, 2);
 
-  const datasetDescriptionFilename = filename.replace('.json', '_dataset_description.json');
+  const datasetDescriptionFilename = datasetName.replace('.json', '_dataset_description.json');
   const datasetDescriptionContent = datasetDescription
     ? JSON.stringify(datasetDescription, null, 2)
     : null;
@@ -112,7 +112,7 @@ ${notes}`;
     checkExists: !forceOverwrite,
     files: [
       {
-        filename,
+        filename: datasetName,
         content: dataDictionaryContent,
         description: `Data dictionary uploaded by ${name} (${email}). Notes: ${notes}`,
       },
@@ -158,9 +158,19 @@ function GoogleDriveUpload({
   const [uploading, setUploading] = useState(false);
   const [uploadSuccess, setUploadSuccess] = useState(false);
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
-  const [showConfirmOverwrite, setShowConfirmOverwrite] = useState(false);
-  const [finalFilename, setFinalFilename] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setFormData((prev) => ({
+        ...prev,
+        datasetName: prev.datasetName || (datasetDescription?.Name as string) || '',
+      }));
+    }
+  }, [open, datasetDescription?.Name]);
+
+  const [finalDatasetName, setFinalDatasetName] = useState('');
   const [suggestedSuffix, setSuggestedSuffix] = useState('');
+  const [showConfirmOverwrite, setShowConfirmOverwrite] = useState(false);
 
   const hasAppsScriptUrl = !!appsScriptUrl;
 
@@ -171,7 +181,7 @@ function GoogleDriveUpload({
       setUploadSuccess(false);
       setUploadedUrl(null);
       setShowConfirmOverwrite(false);
-      setFinalFilename('');
+      setFinalDatasetName('');
       setSuggestedSuffix('');
       setError(null);
       setFormData(initialFormState);
@@ -220,7 +230,7 @@ function GoogleDriveUpload({
     }
   }, [open, hasAppsScriptUrl, fetchSites]);
 
-  const generateFilename = () => {
+  const generateDatasetName = () => {
     const siteSanitized = formData.site.replace(/[^a-z0-9]/gi, '_');
     const datasetSanitized = formData.datasetName
       ? formData.datasetName.replace(/[^a-z0-9]/gi, '_')
@@ -228,7 +238,7 @@ function GoogleDriveUpload({
     return `${siteSanitized}_${datasetSanitized}.json`;
   };
 
-  const handleUpload = async (forceOverwrite = false, overrideFilename?: string) => {
+  const handleUpload = async (forceOverwrite = false, overrideDatasetName?: string) => {
     if (!hasAppsScriptUrl) {
       setError('Google Apps Script URL not configured.');
       return;
@@ -238,9 +248,9 @@ function GoogleDriveUpload({
     setError(null);
 
     try {
-      const filename = overrideFilename || generateFilename();
+      const datasetName = overrideDatasetName || generateDatasetName();
       const payload = createUploadPayload({
-        filename,
+        datasetName,
         dataDictionary,
         datasetDescription,
         notes: formData.notes,
@@ -275,10 +285,10 @@ function GoogleDriveUpload({
           setUploadedUrl(previewUrl);
         }
         // If we didn't have an override filename, it means we used the generated one.
-        if (!overrideFilename) {
-          setFinalFilename(generateFilename());
+        if (!overrideDatasetName) {
+          setFinalDatasetName(generateDatasetName());
         } else {
-          setFinalFilename(overrideFilename);
+          setFinalDatasetName(overrideDatasetName);
         }
       } else if (result.status === 'conflict') {
         setSuggestedSuffix(getTimestampSuffix());
@@ -301,8 +311,8 @@ function GoogleDriveUpload({
       return (
         <div className="flex flex-col gap-4">
           <Alert severity="success" data-cy="upload-success-alert">
-            Successfully uploaded <strong>{finalFilename || generateFilename()}</strong> to Google
-            Drive!
+            Successfully uploaded <strong>{finalDatasetName || generateDatasetName()}</strong> to
+            Google Drive!
           </Alert>
           {uploadedUrl && (
             <Button
@@ -337,18 +347,18 @@ function GoogleDriveUpload({
       return (
         <div className="flex flex-col gap-4 pt-2">
           <Alert severity="warning">
-            A file named <strong>{generateFilename()}</strong> already exists in{' '}
+            A dataset named <strong>{generateDatasetName()}</strong> already exists in{' '}
             <strong>{formData.site}</strong>.
             <br />
             <br />
             We will save this as a new version to avoid overwriting the existing file.
           </Alert>
 
-          <Typography variant="body2" data-cy="new-filename-preview">
+          <Typography variant="body2" data-cy="new-dataset-name-preview">
             The new file will be named:
             <br />
             <strong>
-              {generateFilename().replace(
+              {generateDatasetName().replace(
                 '.json',
                 `_${formData.customSuffix || suggestedSuffix}.json`
               )}
@@ -490,13 +500,13 @@ function GoogleDriveUpload({
 
         <div
           className="mt-2 p-3 bg-gray-50 rounded border border-gray-200"
-          data-cy="filename-preview"
+          data-cy="dataset-name-preview"
         >
           <Typography variant="caption" className="block text-gray-500 uppercase tracking-wide">
-            Filename Preview
+            Dataset Name Preview
           </Typography>
           <Typography variant="body2" className="font-mono text-gray-800">
-            {generateFilename()}
+            {generateDatasetName()}
           </Typography>
         </div>
 
@@ -584,12 +594,12 @@ function GoogleDriveUpload({
         {hasAppsScriptUrl && !uploadSuccess && showConfirmOverwrite && (
           <Button
             onClick={() => {
-              const baseName = generateFilename().replace('.json', '');
+              const baseName = generateDatasetName().replace('.json', '');
               const suffix = formData.customSuffix || suggestedSuffix;
-              const newFilename = `${baseName}_${suffix}.json`;
+              const newDatasetName = `${baseName}_${suffix}.json`;
               // Do NOT close dialog or reset state here, just call upload
               // setShowConfirmOverwrite(false); // REMOVED
-              handleUpload(true, newFilename);
+              handleUpload(true, newDatasetName);
             }}
             color="primary"
             variant="contained"

--- a/src/hooks/useGenerateDatasetDescription.ts
+++ b/src/hooks/useGenerateDatasetDescription.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { useDatasetDescription, useColumns, useStandardizedVariables } from '../stores/data';
+import { DatasetDescription } from '../utils/internal_types';
 import { useDatasetDescriptionFormValidation } from './useDatasetDescriptionFormValidation';
 
-export function useGenerateDatasetDescription() {
+export function useGenerateDatasetDescription(): DatasetDescription | null {
   const datasetDescription = useDatasetDescription();
   const columns = useColumns();
   const standardizedVariables = useStandardizedVariables();
@@ -29,26 +30,38 @@ export function useGenerateDatasetDescription() {
       return null;
     }
 
-    const finalDesc: Record<string, string | number | string[]> = {};
-    const listFields = ['Authors', 'ReferencesAndLinks', 'Keywords'];
+    const finalDesc: DatasetDescription = {
+      Name: datasetDescription.Name.trim(),
+    };
 
-    Object.entries(datasetDescription).forEach(([k, v]) => {
-      if (listFields.includes(k) && typeof v === 'string') {
-        const parsedList = v
-          .split(',')
-          .map((s) => s.trim())
-          .filter((s) => s !== '');
-        if (parsedList.length > 0) {
-          finalDesc[k] = parsedList;
-        }
-      } else if (Array.isArray(v)) {
-        if (v.length > 0) {
-          finalDesc[k] = v;
-        }
-      } else if (typeof v === 'string' && v.trim() !== '') {
-        finalDesc[k] = v.trim();
-      }
-    });
+    const parseList = (str?: string) => {
+      if (!str) return undefined;
+      const parsed = str
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s !== '');
+      return parsed.length > 0 ? parsed : undefined;
+    };
+
+    const authors = parseList(datasetDescription.Authors);
+    if (authors) finalDesc.Authors = authors;
+
+    const references = parseList(datasetDescription.ReferencesAndLinks);
+    if (references) finalDesc.ReferencesAndLinks = references;
+
+    const keywords = parseList(datasetDescription.Keywords);
+    if (keywords) finalDesc.Keywords = keywords;
+
+    if (datasetDescription.AccessType?.trim())
+      finalDesc.AccessType = datasetDescription.AccessType.trim();
+    if (datasetDescription.AccessInstructions?.trim())
+      finalDesc.AccessInstructions = datasetDescription.AccessInstructions.trim();
+    if (datasetDescription.RepositoryURL?.trim())
+      finalDesc.RepositoryURL = datasetDescription.RepositoryURL.trim();
+    if (datasetDescription.AccessEmail?.trim())
+      finalDesc.AccessEmail = datasetDescription.AccessEmail.trim();
+    if (datasetDescription.AccessLink?.trim())
+      finalDesc.AccessLink = datasetDescription.AccessLink.trim();
 
     if (participantCount > 0) {
       finalDesc.ParticipantCount = participantCount;

--- a/src/utils/internal_types.ts
+++ b/src/utils/internal_types.ts
@@ -25,6 +25,19 @@ export interface DatasetDescriptionFormState {
   Keywords: string;
 }
 
+export interface DatasetDescription {
+  Name: string;
+  Authors?: string[];
+  AccessType?: string;
+  AccessInstructions?: string;
+  RepositoryURL?: string;
+  AccessEmail?: string;
+  AccessLink?: string;
+  ReferencesAndLinks?: string[];
+  Keywords?: string[];
+  ParticipantCount?: number;
+}
+
 export type StepConfig = {
   label: string;
   view: View;


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #556

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Updated info alerts on Download and GoogleDriveUpload components
- Refactored Google Drive payload structure from a single file object to a files
array to support uploading the dataset description alongside the data dictionary
- Enforced explicit type mapping for dataset description generation

**NOTE**:
- Before publishing the updated script, ensure the folder ID is the correct one
- The script is backward compatible

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enable uploading a generated dataset description JSON alongside the data dictionary to the ENIGMA-PD Google Drive and adjust related UI messaging.

New Features:
- Generate a typed dataset description object from the dataset description form state for inclusion in uploads.
- Upload both the data dictionary and an optional dataset description file to the ENIGMA-PD Google Drive using a multi-file payload.

Enhancements:
- Introduce a strongly-typed DatasetDescription model to constrain dataset description fields and values.
- Update download and Google Drive upload information alerts to clarify that only the data dictionary and dataset description are uploaded, while tabular data remains local.

Tests:
- Extend GoogleDriveUpload Cypress component tests to cover the new datasetDescription prop and payload shape.