### PR TITLE
[FIX] Align data dictionary filenames with tool expectations

### DIFF
--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -305,7 +305,7 @@ describe('GoogleDriveUpload', () => {
       cy.get('[data-cy="upload-success-alert"]').should('be.visible');
     });
 
-    it('should apply suffix to both data dictionary and dataset description filenames on conflict', () => {
+    it('should determine filename from the manually entered dataset name in the GDrive upload form if mismatch exists with dataset description', () => {
       const mockDatasetDescription = {
         Name: 'Conflict Dataset',
         ParticipantCount: 42,

--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -126,7 +126,7 @@ describe('GoogleDriveUpload', () => {
         const { body } = interception.request;
         // If body is string (text/plain), parse it. If object, use as is.
         const parsed = typeof body === 'string' ? JSON.parse(body) : body;
-        expect(parsed.files[0].filename).to.contain('SuccessDataset');
+        expect(parsed.files[0].filename).to.contain('SuccessDataset_annotated.json');
         expect(parsed.checkExists).to.equal(true);
       });
 
@@ -172,7 +172,7 @@ describe('GoogleDriveUpload', () => {
 
         expect(parsed.files).to.have.length(2);
 
-        expect(parsed.files[0].filename).to.contain('DualFileDataset.json');
+        expect(parsed.files[0].filename).to.contain('DualFileDataset_annotated.json');
 
         expect(parsed.files[1].filename).to.contain('DualFileDataset_dataset_description.json');
         const descriptionContent = JSON.parse(parsed.files[1].content);
@@ -236,8 +236,7 @@ describe('GoogleDriveUpload', () => {
         const { body } = interception.request;
         const parsedBody = typeof body === 'string' ? JSON.parse(body) : body;
         expect(parsedBody.checkExists).to.equal(false);
-        // Not end without prefix
-        expect(parsedBody.files[0].filename).to.not.equal('conflict.json');
+        expect(parsedBody.files[0].filename).to.not.equal('conflict_annotated.json');
       });
 
       cy.get('[data-cy="upload-success-alert"]').should('be.visible');
@@ -304,6 +303,65 @@ describe('GoogleDriveUpload', () => {
       });
 
       cy.get('[data-cy="upload-success-alert"]').should('be.visible');
+    });
+
+    it('should apply suffix to both data dictionary and dataset description filenames on conflict', () => {
+      const mockDatasetDescription = {
+        Name: 'Conflict Dataset',
+        ParticipantCount: 42,
+      };
+
+      cy.mount(
+        <GoogleDriveUpload
+          open={testProps.open}
+          onClose={testProps.onClose}
+          dataDictionary={testProps.dataDictionary}
+          datasetDescription={mockDatasetDescription}
+          appsScriptUrl={testProps.appsScriptUrl}
+          config={testProps.config}
+        />
+      );
+
+      cy.wait('@getSites');
+
+      let conflictHit = false;
+      cy.intercept('POST', '**/exec', (req) => {
+        const body = JSON.parse(req.body);
+        if (body.action !== 'getSites') {
+          if (!conflictHit) {
+            conflictHit = true;
+            req.reply({
+              body: { status: 'conflict' },
+            });
+          } else {
+            req.reply({
+              body: { status: 'success', fileId: '12345' },
+            });
+          }
+        }
+      }).as('createDualFileConflict');
+
+      cy.get('[data-cy="dataset-name-input"]').clear();
+      cy.get('[data-cy="dataset-name-input"]').type('ConflictDualFile');
+      cy.get('[data-cy="password-input"]').type('pass');
+      cy.get('[data-cy="upload-button"]').click();
+
+      cy.wait('@createDualFileConflict');
+
+      cy.get('[data-cy="custom-suffix-input"]').type('v2');
+      cy.get('[data-cy="overwrite-confirm-button"]').click();
+
+      cy.wait('@createDualFileConflict').then((interception) => {
+        const { body } = interception.request;
+        const parsed = typeof body === 'string' ? JSON.parse(body) : body;
+
+        expect(parsed.files).to.have.length(2);
+
+        expect(parsed.files[0].filename).to.equal('SiteA_ConflictDualFile_annotated_v2.json');
+        expect(parsed.files[1].filename).to.equal(
+          'SiteA_ConflictDualFile_v2_dataset_description.json'
+        );
+      });
     });
 
     it('should only show info icon in initial state', () => {

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -72,7 +72,9 @@ const createUploadPayload = ({
 }) => {
   const dataDictionaryContent = JSON.stringify(dataDictionary, null, 2);
 
-  const datasetDescriptionFilename = datasetName.replace('.json', '_dataset_description.json');
+  const datasetDescriptionFilename = datasetName
+    .replace('_annotated', '')
+    .replace('.json', '_dataset_description.json');
   const datasetDescriptionContent = datasetDescription
     ? JSON.stringify(datasetDescription, null, 2)
     : null;
@@ -235,7 +237,7 @@ function GoogleDriveUpload({
     const datasetSanitized = formData.datasetName
       ? formData.datasetName.replace(/[^a-z0-9]/gi, '_')
       : 'dataset';
-    return `${siteSanitized}_${datasetSanitized}.json`;
+    return `${siteSanitized}_${datasetSanitized}_annotated.json`;
   };
 
   const handleUpload = async (forceOverwrite = false, overrideDatasetName?: string) => {


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Aligned uploaded data dictionary filenames to include the `_annotated.json` postfix for consistency with other tools and downloads
- Updated the upload payload generator to automatically strip the `_annotated` tag from dataset description filenames to keep them clean
- Updated existing Cypress component tests to accurately assert the new filename formats and expectations
- Added a new Cypress test to verify that dual-file conflict resolution correctly manages and applies custom suffixes to both the data dictionary and the dataset description files


<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Align Google Drive upload filenames for data dictionaries and dataset descriptions with expected annotated naming conventions and ensure conflict resolution applies suffixes consistently.

Bug Fixes:
- Ensure uploaded data dictionary filenames consistently use the `_annotated.json` suffix expected by downstream tools.
- Generate dataset description filenames without propagating the `_annotated` tag into their base names.

Tests:
- Update existing Cypress component tests to reflect the new annotated filename conventions for uploaded files.
- Add a Cypress test to verify that conflict resolution applies custom suffixes consistently to both data dictionary and dataset description filenames.