### PR TITLE
[ENH] Add context on dataset description fields

### DIFF
--- a/src/components/DatasetDescriptionForm.tsx
+++ b/src/components/DatasetDescriptionForm.tsx
@@ -7,12 +7,20 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Link,
+  Tooltip,
 } from '@mui/material';
 import { useDatasetDescriptionFormValidation } from '../hooks/useDatasetDescriptionFormValidation';
 import { useDatasetDescription, useDataActions } from '../stores/data';
 import { DatasetDescriptionFormState } from '../utils/internal_types';
 
 const ACCESS_TYPES = ['public', 'registered', 'restricted'];
+const ACCESS_TYPE_TOOLTIPS: Record<string, string> = {
+  public: 'Immediately accessible without registration, authentication, or approval.',
+  registered:
+    'Requires authentication or agreement to basic terms of use, but no formal application or review.',
+  restricted: 'Requires formal approval or review of a data access request.',
+};
 
 function ArrayPreviewDisplay({ value, dataCy }: { value: string; dataCy: string }) {
   if (value.trim() === '') return null;
@@ -49,7 +57,16 @@ function DatasetDescriptionForm() {
       </Typography>
       <Typography variant="body2" className="text-gray-600 mb-4">
         This information is what people will see when they first discover your dataset. Fill out
-        this metadata to generate a Neurobagel-compliant dataset_description.json file.
+        this metadata to generate a Neurobagel-compliant dataset_description.json file. For more
+        information about each dataset description field, see the{' '}
+        <Link
+          href="https://neurobagel.org/user_guide/dataset_description/#dataset-description-fields"
+          target="_blank"
+          rel="noreferrer"
+        >
+          docs
+        </Link>
+        .
       </Typography>
 
       <TextField
@@ -97,8 +114,10 @@ function DatasetDescriptionForm() {
             </Typography>
           </AccordionSummary>
           <AccordionDetails className="flex flex-col gap-4 pt-4">
-            <Typography variant="body2" className="text-gray-600">
-              Provide details on how others can access or request this dataset.
+            <Typography variant="body2" className="text-gray-600 mb-2">
+              Provide details on how others can access or request the raw dataset. This information
+              is only intended to describe the dataset’s access conditions and will not have any
+              effect on actual data availability or user permissions.
             </Typography>
             <TextField
               select
@@ -111,7 +130,9 @@ function DatasetDescriptionForm() {
             >
               {ACCESS_TYPES.map((type) => (
                 <MenuItem key={type} value={type}>
-                  {type}
+                  <Tooltip title={ACCESS_TYPE_TOOLTIPS[type]} placement="right" arrow>
+                    <span className="w-full block">{type}</span>
+                  </Tooltip>
                 </MenuItem>
               ))}
             </TextField>
@@ -178,7 +199,8 @@ function DatasetDescriptionForm() {
           </AccordionSummary>
           <AccordionDetails className="flex flex-col gap-4 pt-4">
             <Typography variant="body2" className="text-gray-600">
-              Add links, related papers, and keywords to help others evaluate your dataset.
+              Add links, relevant papers, and keywords to help others better understand your
+              dataset.
             </Typography>
             <Box className="flex flex-col gap-1">
               <TextField

--- a/src/components/DatasetDescriptionForm.tsx
+++ b/src/components/DatasetDescriptionForm.tsx
@@ -56,15 +56,16 @@ function DatasetDescriptionForm() {
         Dataset Description
       </Typography>
       <Typography variant="body2" className="text-gray-600 mb-4">
-        This information is what people will see when they first discover your dataset. Fill out
-        this metadata to generate a Neurobagel-compliant dataset_description.json file. For more
-        information about each dataset description field, see the{' '}
+        The information you enter into this form will be available to download as a
+        dataset_description.json file on the next page. For more. Fill out this metadata to generate
+        a Neurobagel-compliant dataset_description.json file. For more information about each
+        dataset description field, see the{' '}
         <Link
           href="https://neurobagel.org/user_guide/dataset_description/#dataset-description-fields"
           target="_blank"
           rel="noreferrer"
         >
-          docs
+          user guide
         </Link>
         .
       </Typography>
@@ -116,8 +117,8 @@ function DatasetDescriptionForm() {
           <AccordionDetails className="flex flex-col gap-4 pt-4">
             <Typography variant="body2" className="text-gray-600 mb-2">
               Provide details on how others can access or request the raw dataset. This information
-              is only intended to describe the dataset’s access conditions and will not have any
-              effect on actual data availability or user permissions.
+              will be shown to researchers who discover your data and has no effect on the
+              visibility or access restrictions of your data.
             </Typography>
             <TextField
               select


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #564 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Clarify dataset description guidance and access type semantics in the dataset description form UI.

Enhancements:
- Add a link from the dataset description form to the documentation section explaining dataset description fields.
- Refine helper text explaining dataset access conditions to emphasize that it only documents access and does not control permissions or availability.
- Improve descriptive text for additional dataset metadata to better convey its purpose.
- Add tooltips for dataset access type options (public, registered, restricted) to explain their meanings.