### PR TITLE
[FIX] Enforce explicit site selection for Google Drive uploads

### DIFF
--- a/cypress/component/GoogleDriveUpload.cy.tsx
+++ b/cypress/component/GoogleDriveUpload.cy.tsx
@@ -100,6 +100,10 @@ describe('GoogleDriveUpload', () => {
     it('should enable upload button only when required fields are filled', () => {
       cy.get('[data-cy="upload-button"]').should('be.disabled');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
+      cy.get('[data-cy="upload-button"]').should('be.disabled');
+
       cy.get('[data-cy="dataset-name-input"]').type('MyDataset');
       cy.get('[data-cy="upload-button"]').should('be.disabled');
 
@@ -118,6 +122,8 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('createFile');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').type('SuccessDataset');
       cy.get('[data-cy="password-input"]').type('correctPass');
       cy.get('[data-cy="upload-button"]').click();
@@ -162,6 +168,8 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('createDualFile');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').type('DualFileDataset');
       cy.get('[data-cy="password-input"]').type('correctPass');
       cy.get('[data-cy="upload-button"]').click();
@@ -191,6 +199,8 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('createFile');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').type('AuthFailDataset');
       cy.get('[data-cy="password-input"]').type('wrong');
       cy.get('[data-cy="upload-button"]').click();
@@ -220,6 +230,8 @@ describe('GoogleDriveUpload', () => {
           }
         }
       }).as('createFile');
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').type('conflict');
       cy.get('[data-cy="password-input"]').type('correctPass');
       cy.get('[data-cy="upload-button"]').click();
@@ -257,6 +269,9 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('createFileConflict');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
+      cy.tick(500);
       cy.get('[data-cy="dataset-name-input"]').type('TimestampTest');
       cy.get('[data-cy="password-input"]').type('pass');
       cy.get('[data-cy="upload-button"]').click();
@@ -285,6 +300,8 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('createFileCustom');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').type('CustomSuffixTest');
       cy.get('[data-cy="password-input"]').type('pass');
       cy.get('[data-cy="upload-button"]').click();
@@ -341,6 +358,8 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('createDualFileConflict');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').clear();
       cy.get('[data-cy="dataset-name-input"]').type('ConflictDualFile');
       cy.get('[data-cy="password-input"]').type('pass');
@@ -375,6 +394,8 @@ describe('GoogleDriveUpload', () => {
         }
       }).as('uploadSuccess');
 
+      cy.get('[data-cy="site-select"]').click();
+      cy.get('[role="listbox"]').contains('SiteA').click();
       cy.get('[data-cy="dataset-name-input"]').type('InfoIconTest');
       cy.get('[data-cy="password-input"]').type('pass');
       cy.get('[data-cy="upload-button"]').click();

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -494,8 +494,8 @@ function GoogleDriveUpload({
             },
           }}
         >
-          <MenuItem value="" disabled>
-            <em>No site selected</em>
+          <MenuItem value="" disabled sx={{ display: 'none' }}>
+            <span className="text-gray-500">No site selected</span>
           </MenuItem>
           {sites.map((option) => (
             <MenuItem key={option} value={option}>

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -495,7 +495,7 @@ function GoogleDriveUpload({
           }}
         >
           <MenuItem value="" disabled sx={{ display: 'none' }}>
-            <span className="text-gray-500">No site selected</span>
+            <span className="text-gray-500">Please select a site</span>
           </MenuItem>
           {sites.map((option) => (
             <MenuItem key={option} value={option}>

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -218,9 +218,6 @@ function GoogleDriveUpload({
         if (!ignore) {
           if (result.status === 'success' && Array.isArray(result.sites)) {
             setSites(result.sites);
-            if (result.sites.length > 0) {
-              setFormData((prev) => ({ ...prev, site: result.sites[0] }));
-            }
             setShowSiteSuccess(true);
             setTimeout(() => {
               if (!ignore) setShowSiteSuccess(false);
@@ -478,10 +475,13 @@ function GoogleDriveUpload({
           value={formData.site}
           onChange={(e) => setFormData({ ...formData, site: e.target.value })}
           fullWidth
+          required
           disabled={loadingSites}
           data-cy="site-select"
           helperText={loadingSites ? 'Fetching sites from Google Drive...' : ''}
           slotProps={{
+            select: { displayEmpty: true },
+            inputLabel: { shrink: true },
             input: {
               endAdornment: (
                 <InputAdornment position="end" sx={{ marginRight: 2 }}>
@@ -494,6 +494,9 @@ function GoogleDriveUpload({
             },
           }}
         >
+          <MenuItem value="" disabled>
+            <em>No site selected</em>
+          </MenuItem>
           {sites.map((option) => (
             <MenuItem key={option} value={option}>
               {option}
@@ -608,7 +611,7 @@ function GoogleDriveUpload({
             onClick={() => handleUpload(false)}
             variant="contained"
             color="primary"
-            disabled={uploading || !formData.datasetName || !formData.password}
+            disabled={uploading || !formData.site || !formData.datasetName || !formData.password}
             data-cy="upload-button"
           >
             {uploading ? 'Uploading...' : 'Upload'}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #577

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Removed automatic default site selection to prevent accidental uploads to the first site
- Added an empty 'No site selected' placeholder and enforced 'required' validation
- Disabled the upload button until a valid site is chosen by the user

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enforce explicit site selection before Google Drive dataset uploads and update validation accordingly.

Bug Fixes:
- Prevent unintended uploads to a default site by removing automatic site preselection and requiring user choice.
- Ensure the upload button remains disabled until a site, dataset name, and password are all provided.

Enhancements:
- Add a placeholder 'No site selected' option and required validation to the site selection field for clearer user guidance.

Tests:
- Update Google Drive upload Cypress tests to select a site explicitly and verify the new upload-button enablement conditions.