### PR TITLE
[MNT] Refactor `GoogleDriveUpload` component

### DIFF
--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -17,8 +17,12 @@ import {
   IconButton,
   Collapse,
 } from '@mui/material';
-import { useState, useEffect } from 'react';
-import { DataDictionary, DatasetDescription } from '../utils/internal_types';
+import { useGoogleDriveUpload } from '../hooks/useGoogleDriveUpload';
+import {
+  DataDictionary,
+  DatasetDescription,
+  GoogleDriveUploadFormState,
+} from '../utils/internal_types';
 
 interface GoogleDriveUploadProps {
   open: boolean;
@@ -29,118 +33,309 @@ interface GoogleDriveUploadProps {
   config: string;
 }
 
-interface FormState {
-  site: string;
-  name: string;
-  email: string;
-  datasetName: string;
-  notes: string;
-  password: string;
-  reuploadReason: string;
-  customSuffix: string;
-}
-
 const defaultProps = {
   appsScriptUrl: import.meta.env.NB_GOOGLE_APPS_SCRIPT_URL,
 };
 
-const getTimestampSuffix = () =>
-  new Date().toISOString().replace(/[-:]/g, '').replace('T', '_').split('.')[0];
+interface UploadSuccessViewProps {
+  finalDatasetName: string;
+  uploadedUrl: string | null;
+  generateDatasetName: () => string;
+}
 
-const createUploadPayload = ({
-  datasetName,
-  dataDictionary,
-  datasetDescription,
-  notes,
-  reuploadReason,
-  name,
-  email,
-  site,
-  password,
-  forceOverwrite,
-}: {
-  datasetName: string;
-  dataDictionary: DataDictionary;
-  datasetDescription: DatasetDescription | null;
-  notes: string;
-  reuploadReason: string;
-  name: string;
-  email: string;
-  site: string;
-  password?: string;
-  forceOverwrite: boolean;
-}) => {
-  const dataDictionaryContent = JSON.stringify(dataDictionary, null, 2);
+function UploadSuccessView({
+  finalDatasetName,
+  uploadedUrl,
+  generateDatasetName,
+}: UploadSuccessViewProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Alert severity="success" data-cy="upload-success-alert">
+        Successfully uploaded <strong>{finalDatasetName || generateDatasetName()}</strong> to Google
+        Drive!
+      </Alert>
+      {uploadedUrl && (
+        <Button
+          variant="outlined"
+          target="_blank"
+          rel="noopener noreferrer"
+          href={uploadedUrl}
+          startIcon={<OpenInNewIcon />}
+          sx={{ mt: 1 }}
+          data-cy="open-drive-file-button"
+        >
+          Open File in Google Drive
+        </Button>
+      )}
+    </div>
+  );
+}
 
-  const datasetDescriptionFilename = datasetName
-    .replace('_annotated', '')
-    .replace('.json', '_dataset_description.json');
-  const datasetDescriptionContent = datasetDescription
-    ? JSON.stringify(datasetDescription, null, 2)
-    : null;
+function ConfigErrorView({ config }: { config: string }) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-8">
+      <Alert severity="error" data-cy="config-error-alert">
+        The data dictionary upload for <strong>{config}</strong> is not available.
+        <br />
+        Please contact your community admin to enable it.
+      </Alert>
+    </div>
+  );
+}
 
-  let commentsContent;
-  const hasNotes = notes && notes.trim().length > 0;
-  const hasReason = reuploadReason && reuploadReason.trim().length > 0;
+interface OverwriteConfirmViewProps {
+  formData: GoogleDriveUploadFormState;
+  setFormData: React.Dispatch<React.SetStateAction<GoogleDriveUploadFormState>>;
+  suggestedSuffix: string;
+  generateDatasetName: () => string;
+  uploading: boolean;
+  error: string | null;
+}
 
-  if (hasNotes || hasReason) {
-    commentsContent = `Uploader Metadata
-=================
-Name:  ${name || 'Anonymous'}
-Email: ${email || 'N/A'}
-Date:  ${new Date().toLocaleString()}
+function OverwriteConfirmView({
+  formData,
+  setFormData,
+  suggestedSuffix,
+  generateDatasetName,
+  uploading,
+  error,
+}: OverwriteConfirmViewProps) {
+  return (
+    <div className="flex flex-col gap-4 pt-2">
+      <Alert severity="warning">
+        A dataset named <strong>{generateDatasetName()}</strong> already exists in{' '}
+        <strong>{formData.site}</strong>.
+        <br />
+        <br />
+        We will save this as a new version to avoid overwriting the existing file.
+      </Alert>
 
-`;
+      <Typography variant="body2" data-cy="new-dataset-name-preview">
+        The new file will be named:
+        <br />
+        <strong>
+          {generateDatasetName().replace(
+            '.json',
+            `_${formData.customSuffix || suggestedSuffix}.json`
+          )}
+        </strong>
+      </Typography>
 
-    if (hasReason) {
-      commentsContent += `Re-upload Reason:
------------------
-${reuploadReason}
+      <TextField
+        label="Custom Suffix (Optional)"
+        value={formData.customSuffix}
+        onChange={(e) =>
+          setFormData({
+            ...formData,
+            customSuffix: e.target.value.replace(/[^a-z0-9_-]/gi, ''),
+          })
+        }
+        placeholder={`e.g. v2 (default: ${suggestedSuffix})`}
+        fullWidth
+        helperText="Only letters, numbers, hyphens, and underscores allowed."
+        data-cy="custom-suffix-input"
+      />
 
-`;
-    }
+      <TextField
+        label="Reason for re-upload / changes"
+        value={formData.reuploadReason}
+        onChange={(e) => setFormData({ ...formData, reuploadReason: e.target.value })}
+        fullWidth
+        multiline
+        rows={2}
+        data-cy="reupload-reason-input"
+        helperText="Optional: Add a note about why this version is being created."
+      />
 
-    if (hasNotes) {
-      commentsContent += `User Notes/Comments:
---------------------
-${notes}`;
-    }
-  }
+      {uploading && <LinearProgress data-cy="upload-progress" />}
+      {error && (
+        <Alert severity="error" data-cy="upload-error-alert">
+          {error}
+        </Alert>
+      )}
+    </div>
+  );
+}
 
-  return {
-    folderName: site,
-    password,
-    commentsContent,
-    checkExists: !forceOverwrite,
-    files: [
-      {
-        filename: datasetName,
-        content: dataDictionaryContent,
-        description: `Data dictionary uploaded by ${name} (${email}). Notes: ${notes}`,
-      },
-      ...(datasetDescriptionContent
-        ? [
-            {
-              filename: datasetDescriptionFilename,
-              content: datasetDescriptionContent,
-              description: `Dataset description uploaded by ${name} (${email}).`,
+interface UploadFormViewProps {
+  showUploadInfo: boolean;
+  formData: GoogleDriveUploadFormState;
+  setFormData: React.Dispatch<React.SetStateAction<GoogleDriveUploadFormState>>;
+  sites: string[];
+  loadingSites: boolean;
+  showSiteSuccess: boolean;
+  generateDatasetName: () => string;
+  uploading: boolean;
+  error: string | null;
+}
+
+function UploadFormView({
+  showUploadInfo,
+  formData,
+  setFormData,
+  sites,
+  loadingSites,
+  showSiteSuccess,
+  generateDatasetName,
+  uploading,
+  error,
+}: UploadFormViewProps) {
+  return (
+    <div className="flex flex-col gap-4 pt-2">
+      <Collapse in={showUploadInfo}>
+        <Alert
+          severity="info"
+          className="mb-2 w-full"
+          variant="filled"
+          sx={{
+            bgcolor: '#e5f6fd', // light cyan background
+            borderLeft: '4px solid #0288d1', // info blue border
+            color: 'rgba(0, 0, 0, 0.87)', // dark test for readability
+            '& .MuiAlert-icon': {
+              color: '#0288d1',
             },
-          ]
-        : []),
-    ],
-  };
-};
+          }}
+        >
+          <Typography variant="subtitle2" className="font-bold mb-1">
+            About this upload:
+          </Typography>
+          <ul className="list-disc pl-5">
+            <li>
+              <Typography variant="body2">
+                The data dictionary and dataset description (if complete) will be uploaded. Your
+                tabular data remains local.
+              </Typography>
+            </li>
+            <li>
+              <Typography variant="body2">
+                The files will be uploaded to a private Google Drive folder for the ENIGMA-PD
+                community.
+              </Typography>
+            </li>
+            <li>
+              <Typography variant="body2">
+                Refer to the &quot;Data Dictionary&quot; preview section above to see the exact
+                content being uploaded.
+              </Typography>
+            </li>
+          </ul>
+        </Alert>
+      </Collapse>
 
-const initialFormState: FormState = {
-  site: '',
-  name: '',
-  email: '',
-  datasetName: '',
-  notes: '',
-  password: '',
-  reuploadReason: '',
-  customSuffix: '',
-};
+      <Typography
+        variant="subtitle2"
+        className="text-gray-500 uppercase tracking-wide font-semibold"
+      >
+        File Details
+      </Typography>
+      <TextField
+        select
+        label="Site"
+        value={formData.site}
+        onChange={(e) => setFormData({ ...formData, site: e.target.value })}
+        fullWidth
+        required
+        disabled={loadingSites}
+        data-cy="site-select"
+        helperText={loadingSites ? 'Fetching sites from Google Drive...' : ''}
+        slotProps={{
+          select: { displayEmpty: true },
+          inputLabel: { shrink: true },
+          input: {
+            endAdornment: (
+              <InputAdornment position="end" sx={{ marginRight: 2 }}>
+                {loadingSites && <CircularProgress size={20} color="inherit" />}
+                {!loadingSites && showSiteSuccess && (
+                  <CheckCircleIcon color="success" fontSize="small" />
+                )}
+              </InputAdornment>
+            ),
+          },
+        }}
+      >
+        <MenuItem value="" disabled sx={{ display: 'none' }}>
+          <span className="text-gray-500">Please select a site</span>
+        </MenuItem>
+        {sites.map((option: string) => (
+          <MenuItem key={option} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </TextField>
+
+      <TextField
+        label="Dataset Name"
+        value={formData.datasetName}
+        onChange={(e) => setFormData({ ...formData, datasetName: e.target.value })}
+        fullWidth
+        required
+        placeholder="e.g. My Study 2026"
+        data-cy="dataset-name-input"
+      />
+
+      <TextField
+        label="Password"
+        type="password"
+        value={formData.password}
+        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+        fullWidth
+        required
+        data-cy="password-input"
+      />
+
+      <div
+        className="mt-2 p-3 bg-gray-50 rounded border border-gray-200"
+        data-cy="dataset-name-preview"
+      >
+        <Typography variant="caption" className="block text-gray-500 uppercase tracking-wide">
+          Dataset Name Preview
+        </Typography>
+        <Typography variant="body2" className="font-mono text-gray-800">
+          {generateDatasetName()}
+        </Typography>
+      </div>
+
+      <Typography
+        variant="subtitle2"
+        className="block text-gray-500 uppercase tracking-wide font-semibold mt-4"
+      >
+        Feedback
+      </Typography>
+      <div className="grid grid-cols-2 gap-4">
+        <TextField
+          label="Name"
+          value={formData.name}
+          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+          fullWidth
+          data-cy="user-name-input"
+        />
+        <TextField
+          label="Email"
+          value={formData.email}
+          onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+          fullWidth
+          data-cy="user-email-input"
+        />
+      </div>
+      <TextField
+        label="Questions / Comments / Problems"
+        value={formData.notes}
+        onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+        multiline
+        rows={3}
+        fullWidth
+        data-cy="user-notes-input"
+      />
+
+      {uploading && <LinearProgress data-cy="upload-progress" />}
+      {error && (
+        <Alert severity="error" data-cy="upload-error-alert">
+          {error}
+        </Alert>
+      )}
+    </div>
+  );
+}
 
 function GoogleDriveUpload({
   open,
@@ -150,431 +345,74 @@ function GoogleDriveUpload({
   appsScriptUrl = import.meta.env.NB_GOOGLE_APPS_SCRIPT_URL,
   config,
 }: GoogleDriveUploadProps) {
-  const [error, setError] = useState<string | null>(null);
-  const [sites, setSites] = useState<string[]>([]);
-  const [loadingSites, setLoadingSites] = useState(false);
-  const [showSiteSuccess, setShowSiteSuccess] = useState(false);
-  const [showUploadInfo, setShowUploadInfo] = useState(false);
-
-  const [formData, setFormData] = useState<FormState>(initialFormState);
-  const [uploading, setUploading] = useState(false);
-  const [uploadSuccess, setUploadSuccess] = useState(false);
-  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
-
-  const [prevOpen, setPrevOpen] = useState(open);
-
-  const hasAppsScriptUrl = !!appsScriptUrl;
-
-  if (open !== prevOpen) {
-    setPrevOpen(open);
-    if (open) {
-      setFormData((prev) => ({
-        ...prev,
-        datasetName: prev.datasetName || (datasetDescription?.Name as string) || '',
-      }));
-      if (hasAppsScriptUrl) {
-        setLoadingSites(true);
-        setShowSiteSuccess(false);
-        setError(null);
-      }
-    }
-  }
-
-  const [finalDatasetName, setFinalDatasetName] = useState('');
-  const [suggestedSuffix, setSuggestedSuffix] = useState('');
-  const [showConfirmOverwrite, setShowConfirmOverwrite] = useState(false);
+  const {
+    error,
+    sites,
+    loadingSites,
+    showSiteSuccess,
+    showUploadInfo,
+    setShowUploadInfo,
+    formData,
+    setFormData,
+    uploading,
+    uploadSuccess,
+    uploadedUrl,
+    hasAppsScriptUrl,
+    finalDatasetName,
+    suggestedSuffix,
+    showConfirmOverwrite,
+    generateDatasetName,
+    handleUpload,
+    resetState,
+  } = useGoogleDriveUpload({ open, appsScriptUrl, dataDictionary, datasetDescription });
 
   const handleClose = () => {
     onClose();
-    // Wait for the exit animation to finish before resetting state
     setTimeout(() => {
-      setUploadSuccess(false);
-      setUploadedUrl(null);
-      setShowConfirmOverwrite(false);
-      setFinalDatasetName('');
-      setSuggestedSuffix('');
-      setError(null);
-      setFormData(initialFormState);
+      resetState();
     }, 300);
-  };
-
-  useEffect(() => {
-    let ignore = false;
-
-    async function fetchSites() {
-      try {
-        const response = await fetch(appsScriptUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'text/plain;charset=utf-8' },
-          body: JSON.stringify({ action: 'getSites' }),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch site names: ${response.status} ${response.statusText}`);
-        }
-
-        const result = await response.json();
-
-        if (!ignore) {
-          if (result.status === 'success' && Array.isArray(result.sites)) {
-            setSites(result.sites);
-            setShowSiteSuccess(true);
-            setTimeout(() => {
-              if (!ignore) setShowSiteSuccess(false);
-            }, 2000);
-          } else {
-            throw new Error(result.message || 'Failed to load sites from Google Drive.');
-          }
-        }
-      } catch (fetchErr) {
-        if (!ignore) {
-          const message =
-            fetchErr instanceof Error ? fetchErr.message : 'Unknown error loading sites';
-          setError(message);
-        }
-      } finally {
-        if (!ignore) {
-          setLoadingSites(false);
-        }
-      }
-    }
-
-    if (open && hasAppsScriptUrl) {
-      // The loading states are already set during render,
-      // so this just kicks off the async network request
-      fetchSites();
-    }
-
-    return () => {
-      ignore = true;
-    };
-  }, [open, hasAppsScriptUrl, appsScriptUrl]);
-
-  const generateDatasetName = () => {
-    const siteSanitized = formData.site.replace(/[^a-z0-9]/gi, '_');
-    const datasetSanitized = formData.datasetName
-      ? formData.datasetName.replace(/[^a-z0-9]/gi, '_')
-      : 'dataset';
-    return `${siteSanitized}_${datasetSanitized}_annotated.json`;
-  };
-
-  const handleUpload = async (forceOverwrite = false, overrideDatasetName?: string) => {
-    if (!hasAppsScriptUrl) {
-      setError('Google Apps Script URL not configured.');
-      return;
-    }
-
-    setUploading(true);
-    setError(null);
-
-    try {
-      const datasetName = overrideDatasetName || generateDatasetName();
-      const payload = createUploadPayload({
-        datasetName,
-        dataDictionary,
-        datasetDescription,
-        notes: formData.notes,
-        reuploadReason: formData.reuploadReason,
-        name: formData.name,
-        email: formData.email,
-        site: formData.site,
-        password: formData.password,
-        forceOverwrite,
-      });
-
-      const scriptUrl = appsScriptUrl;
-
-      const response = await fetch(scriptUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/plain;charset=utf-8',
-        },
-        body: JSON.stringify(payload),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Network response was not ok: ${response.status}`);
-      }
-
-      const result = await response.json();
-
-      if (result.status === 'success') {
-        setUploadSuccess(true);
-        if (result.fileId) {
-          const previewUrl = `https://drive.google.com/file/d/${result.fileId}/view`;
-          setUploadedUrl(previewUrl);
-        }
-        // If we didn't have an override filename, it means we used the generated one.
-        if (!overrideDatasetName) {
-          setFinalDatasetName(generateDatasetName());
-        } else {
-          setFinalDatasetName(overrideDatasetName);
-        }
-      } else if (result.status === 'conflict') {
-        setSuggestedSuffix(getTimestampSuffix());
-        setShowConfirmOverwrite(true);
-      } else if (result.status === 'auth_failed') {
-        throw new Error(result.message || 'Authentication failed. Please check your password.');
-      } else {
-        throw new Error(result.message || 'Unknown error');
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      setError(`Upload failed: ${message}`);
-    } finally {
-      setUploading(false);
-    }
   };
 
   const renderContent = () => {
     if (uploadSuccess) {
       return (
-        <div className="flex flex-col gap-4">
-          <Alert severity="success" data-cy="upload-success-alert">
-            Successfully uploaded <strong>{finalDatasetName || generateDatasetName()}</strong> to
-            Google Drive!
-          </Alert>
-          {uploadedUrl && (
-            <Button
-              variant="outlined"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={uploadedUrl}
-              startIcon={<OpenInNewIcon />}
-              sx={{ mt: 1 }}
-              data-cy="open-drive-file-button"
-            >
-              Open File in Google Drive
-            </Button>
-          )}
-        </div>
+        <UploadSuccessView
+          finalDatasetName={finalDatasetName}
+          uploadedUrl={uploadedUrl}
+          generateDatasetName={generateDatasetName}
+        />
       );
     }
 
     if (!hasAppsScriptUrl) {
-      return (
-        <div className="flex flex-col items-center gap-4 py-8">
-          <Alert severity="error" data-cy="config-error-alert">
-            The data dictionary upload for <strong>{config}</strong> is not available.
-            <br />
-            Please contact your community admin to enable it.
-          </Alert>
-        </div>
-      );
+      return <ConfigErrorView config={config} />;
     }
 
     if (showConfirmOverwrite) {
       return (
-        <div className="flex flex-col gap-4 pt-2">
-          <Alert severity="warning">
-            A dataset named <strong>{generateDatasetName()}</strong> already exists in{' '}
-            <strong>{formData.site}</strong>.
-            <br />
-            <br />
-            We will save this as a new version to avoid overwriting the existing file.
-          </Alert>
-
-          <Typography variant="body2" data-cy="new-dataset-name-preview">
-            The new file will be named:
-            <br />
-            <strong>
-              {generateDatasetName().replace(
-                '.json',
-                `_${formData.customSuffix || suggestedSuffix}.json`
-              )}
-            </strong>
-          </Typography>
-
-          <TextField
-            label="Custom Suffix (Optional)"
-            value={formData.customSuffix}
-            onChange={(e) =>
-              setFormData({
-                ...formData,
-                customSuffix: e.target.value.replace(/[^a-z0-9_-]/gi, ''),
-              })
-            }
-            placeholder={`e.g. v2 (default: ${suggestedSuffix})`}
-            fullWidth
-            helperText="Only letters, numbers, hyphens, and underscores allowed."
-            data-cy="custom-suffix-input"
-          />
-
-          <TextField
-            label="Reason for re-upload / changes"
-            value={formData.reuploadReason}
-            onChange={(e) => setFormData({ ...formData, reuploadReason: e.target.value })}
-            fullWidth
-            multiline
-            rows={2}
-            data-cy="reupload-reason-input"
-            helperText="Optional: Add a note about why this version is being created."
-          />
-
-          {uploading && <LinearProgress data-cy="upload-progress" />}
-          {error && (
-            <Alert severity="error" data-cy="upload-error-alert">
-              {error}
-            </Alert>
-          )}
-        </div>
+        <OverwriteConfirmView
+          formData={formData}
+          setFormData={setFormData}
+          suggestedSuffix={suggestedSuffix}
+          generateDatasetName={generateDatasetName}
+          uploading={uploading}
+          error={error}
+        />
       );
     }
 
     return (
-      <div className="flex flex-col gap-4 pt-2">
-        <Collapse in={showUploadInfo}>
-          <Alert
-            severity="info"
-            className="mb-2 w-full"
-            variant="filled"
-            sx={{
-              bgcolor: '#e5f6fd', // light cyan background
-              borderLeft: '4px solid #0288d1', // info blue border
-              color: 'rgba(0, 0, 0, 0.87)', // dark test for readability
-              '& .MuiAlert-icon': {
-                color: '#0288d1',
-              },
-            }}
-          >
-            <Typography variant="subtitle2" className="font-bold mb-1">
-              About this upload:
-            </Typography>
-            <ul className="list-disc pl-5">
-              <li>
-                <Typography variant="body2">
-                  The data dictionary and dataset description (if complete) will be uploaded. Your
-                  tabular data remains local.
-                </Typography>
-              </li>
-              <li>
-                <Typography variant="body2">
-                  The files will be uploaded to a private Google Drive folder for the ENIGMA-PD
-                  community.
-                </Typography>
-              </li>
-              <li>
-                <Typography variant="body2">
-                  Refer to the &quot;Data Dictionary&quot; preview section above to see the exact
-                  content being uploaded.
-                </Typography>
-              </li>
-            </ul>
-          </Alert>
-        </Collapse>
-
-        <Typography
-          variant="subtitle2"
-          className="text-gray-500 uppercase tracking-wide font-semibold"
-        >
-          File Details
-        </Typography>
-        <TextField
-          select
-          label="Site"
-          value={formData.site}
-          onChange={(e) => setFormData({ ...formData, site: e.target.value })}
-          fullWidth
-          required
-          disabled={loadingSites}
-          data-cy="site-select"
-          helperText={loadingSites ? 'Fetching sites from Google Drive...' : ''}
-          slotProps={{
-            select: { displayEmpty: true },
-            inputLabel: { shrink: true },
-            input: {
-              endAdornment: (
-                <InputAdornment position="end" sx={{ marginRight: 2 }}>
-                  {loadingSites && <CircularProgress size={20} color="inherit" />}
-                  {!loadingSites && showSiteSuccess && (
-                    <CheckCircleIcon color="success" fontSize="small" />
-                  )}
-                </InputAdornment>
-              ),
-            },
-          }}
-        >
-          <MenuItem value="" disabled sx={{ display: 'none' }}>
-            <span className="text-gray-500">Please select a site</span>
-          </MenuItem>
-          {sites.map((option) => (
-            <MenuItem key={option} value={option}>
-              {option}
-            </MenuItem>
-          ))}
-        </TextField>
-
-        <TextField
-          label="Dataset Name"
-          value={formData.datasetName}
-          onChange={(e) => setFormData({ ...formData, datasetName: e.target.value })}
-          fullWidth
-          required
-          placeholder="e.g. My Study 2026"
-          data-cy="dataset-name-input"
-        />
-
-        <TextField
-          label="Password"
-          type="password"
-          value={formData.password}
-          onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-          fullWidth
-          required
-          data-cy="password-input"
-        />
-
-        <div
-          className="mt-2 p-3 bg-gray-50 rounded border border-gray-200"
-          data-cy="dataset-name-preview"
-        >
-          <Typography variant="caption" className="block text-gray-500 uppercase tracking-wide">
-            Dataset Name Preview
-          </Typography>
-          <Typography variant="body2" className="font-mono text-gray-800">
-            {generateDatasetName()}
-          </Typography>
-        </div>
-
-        <Typography
-          variant="subtitle2"
-          className="block text-gray-500 uppercase tracking-wide font-semibold mt-4"
-        >
-          Feedback
-        </Typography>
-        <div className="grid grid-cols-2 gap-4">
-          <TextField
-            label="Name"
-            value={formData.name}
-            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            fullWidth
-            data-cy="user-name-input"
-          />
-          <TextField
-            label="Email"
-            value={formData.email}
-            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-            fullWidth
-            data-cy="user-email-input"
-          />
-        </div>
-        <TextField
-          label="Questions / Comments / Problems"
-          value={formData.notes}
-          onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-          multiline
-          rows={3}
-          fullWidth
-          data-cy="user-notes-input"
-        />
-
-        {uploading && <LinearProgress data-cy="upload-progress" />}
-        {error && (
-          <Alert severity="error" data-cy="upload-error-alert">
-            {error}
-          </Alert>
-        )}
-      </div>
+      <UploadFormView
+        showUploadInfo={showUploadInfo}
+        formData={formData}
+        setFormData={setFormData}
+        sites={sites}
+        loadingSites={loadingSites}
+        showSiteSuccess={showSiteSuccess}
+        generateDatasetName={generateDatasetName}
+        uploading={uploading}
+        error={error}
+      />
     );
   };
 

--- a/src/hooks/useGoogleDriveUpload.ts
+++ b/src/hooks/useGoogleDriveUpload.ts
@@ -1,0 +1,220 @@
+import { useState, useEffect } from 'react';
+import {
+  DataDictionary,
+  DatasetDescription,
+  GoogleDriveUploadFormState,
+} from '../utils/internal_types';
+import { createUploadPayload, getTimestampSuffix } from '../utils/util';
+
+interface UseGoogleDriveUploadProps {
+  open: boolean;
+  appsScriptUrl?: string;
+  dataDictionary: DataDictionary;
+  datasetDescription: DatasetDescription | null;
+}
+
+export const initialFormState: GoogleDriveUploadFormState = {
+  site: '',
+  name: '',
+  email: '',
+  datasetName: '',
+  notes: '',
+  password: '',
+  reuploadReason: '',
+  customSuffix: '',
+};
+
+export function useGoogleDriveUpload({
+  open,
+  appsScriptUrl,
+  dataDictionary,
+  datasetDescription,
+}: UseGoogleDriveUploadProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [sites, setSites] = useState<string[]>([]);
+  const [loadingSites, setLoadingSites] = useState(false);
+  const [showSiteSuccess, setShowSiteSuccess] = useState(false);
+  const [showUploadInfo, setShowUploadInfo] = useState(false);
+
+  const [formData, setFormData] = useState<GoogleDriveUploadFormState>(initialFormState);
+  const [uploading, setUploading] = useState(false);
+  const [uploadSuccess, setUploadSuccess] = useState(false);
+  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
+
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  const hasAppsScriptUrl = !!appsScriptUrl;
+
+  const [finalDatasetName, setFinalDatasetName] = useState('');
+  const [suggestedSuffix, setSuggestedSuffix] = useState('');
+  const [showConfirmOverwrite, setShowConfirmOverwrite] = useState(false);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setFormData((prev) => ({
+        ...prev,
+        datasetName: prev.datasetName || (datasetDescription?.Name as string) || '',
+      }));
+      if (hasAppsScriptUrl) {
+        setLoadingSites(true);
+        setShowSiteSuccess(false);
+        setError(null);
+      }
+    }
+  }
+
+  const resetState = () => {
+    setUploadSuccess(false);
+    setUploadedUrl(null);
+    setShowConfirmOverwrite(false);
+    setFinalDatasetName('');
+    setSuggestedSuffix('');
+    setError(null);
+    setFormData(initialFormState);
+  };
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function fetchSites() {
+      try {
+        const response = await fetch(appsScriptUrl!, {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+          body: JSON.stringify({ action: 'getSites' }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch site names: ${response.status} ${response.statusText}`);
+        }
+
+        const result = await response.json();
+
+        if (!ignore) {
+          if (result.status === 'success' && Array.isArray(result.sites)) {
+            setSites(result.sites);
+            setShowSiteSuccess(true);
+            setTimeout(() => {
+              if (!ignore) setShowSiteSuccess(false);
+            }, 2000);
+          } else {
+            throw new Error(result.message || 'Failed to load sites from Google Drive.');
+          }
+        }
+      } catch (fetchErr) {
+        if (!ignore) {
+          const message =
+            fetchErr instanceof Error ? fetchErr.message : 'Unknown error loading sites';
+          setError(message);
+        }
+      } finally {
+        if (!ignore) {
+          setLoadingSites(false);
+        }
+      }
+    }
+
+    if (open && hasAppsScriptUrl) {
+      fetchSites();
+    }
+
+    return () => {
+      ignore = true;
+    };
+  }, [open, hasAppsScriptUrl, appsScriptUrl]);
+
+  const generateDatasetName = () => {
+    const siteSanitized = formData.site.replace(/[^a-z0-9]/gi, '_');
+    const datasetSanitized = formData.datasetName
+      ? formData.datasetName.replace(/[^a-z0-9]/gi, '_')
+      : 'dataset';
+    return `${siteSanitized}_${datasetSanitized}_annotated.json`;
+  };
+
+  const handleUpload = async (forceOverwrite = false, overrideDatasetName?: string) => {
+    if (!hasAppsScriptUrl) {
+      setError('Google Apps Script URL not configured.');
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+
+    try {
+      const datasetName = overrideDatasetName || generateDatasetName();
+      const payload = createUploadPayload({
+        datasetName,
+        dataDictionary,
+        datasetDescription,
+        notes: formData.notes,
+        reuploadReason: formData.reuploadReason,
+        name: formData.name,
+        email: formData.email,
+        site: formData.site,
+        password: formData.password,
+        forceOverwrite,
+      });
+
+      const response = await fetch(appsScriptUrl!, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain;charset=utf-8',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Network response was not ok: ${response.status}`);
+      }
+
+      const result = await response.json();
+
+      if (result.status === 'success') {
+        setUploadSuccess(true);
+        if (result.fileId) {
+          const previewUrl = `https://drive.google.com/file/d/${result.fileId}/view`;
+          setUploadedUrl(previewUrl);
+        }
+        if (!overrideDatasetName) {
+          setFinalDatasetName(generateDatasetName());
+        } else {
+          setFinalDatasetName(overrideDatasetName);
+        }
+      } else if (result.status === 'conflict') {
+        setSuggestedSuffix(getTimestampSuffix());
+        setShowConfirmOverwrite(true);
+      } else if (result.status === 'auth_failed') {
+        throw new Error(result.message || 'Authentication failed. Please check your password.');
+      } else {
+        throw new Error(result.message || 'Unknown error');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(`Upload failed: ${message}`);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return {
+    error,
+    sites,
+    loadingSites,
+    showSiteSuccess,
+    showUploadInfo,
+    setShowUploadInfo,
+    formData,
+    setFormData,
+    uploading,
+    uploadSuccess,
+    uploadedUrl,
+    hasAppsScriptUrl,
+    finalDatasetName,
+    suggestedSuffix,
+    showConfirmOverwrite,
+    generateDatasetName,
+    handleUpload,
+    resetState,
+  };
+}

--- a/src/utils/internal_types.ts
+++ b/src/utils/internal_types.ts
@@ -231,3 +231,27 @@ export interface StandardizedVariableItem {
   can_have_multiple_columns?: boolean;
   terms?: StandardizedTermItem[];
 }
+
+export interface GoogleDriveUploadFormState {
+  site: string;
+  name: string;
+  email: string;
+  datasetName: string;
+  notes: string;
+  password: string;
+  reuploadReason: string;
+  customSuffix: string;
+}
+
+export interface GoogleDriveUploadPayload {
+  datasetName: string;
+  dataDictionary: DataDictionary;
+  datasetDescription: DatasetDescription | null;
+  notes: string;
+  reuploadReason: string;
+  name: string;
+  email: string;
+  site: string;
+  password?: string;
+  forceOverwrite: boolean;
+}

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,3 +1,5 @@
+import { GoogleDriveUploadPayload } from './internal_types';
+
 export function getColumnsAssignedText(mappedColumnsCount: number): string {
   if (mappedColumnsCount === 0) return 'No columns assigned';
   if (mappedColumnsCount === 1) return '1 column assigned';
@@ -27,3 +29,67 @@ export const isValidUrl = (string: string) => {
 // Email regex corresponds to the HTML5 specification (approximates the RFC 5322 standard used by Pydantic's email-validator)
 export const emailRegex =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export const getTimestampSuffix = (): string =>
+  new Date().toISOString().replace(/[-:]/g, '').replace('T', '_').split('.')[0];
+
+export const createUploadPayload = ({
+  datasetName,
+  dataDictionary,
+  datasetDescription,
+  notes,
+  reuploadReason,
+  name,
+  email,
+  site,
+  password,
+  forceOverwrite,
+}: GoogleDriveUploadPayload) => {
+  const dataDictionaryContent = JSON.stringify(dataDictionary, null, 2);
+
+  const datasetDescriptionFilename = datasetName
+    .replace('_annotated', '')
+    .replace('.json', '_dataset_description.json');
+  const datasetDescriptionContent = datasetDescription
+    ? JSON.stringify(datasetDescription, null, 2)
+    : null;
+
+  let commentsContent;
+  const hasNotes = notes && notes.trim().length > 0;
+  const hasReason = reuploadReason && reuploadReason.trim().length > 0;
+
+  if (hasNotes || hasReason) {
+    commentsContent = `Uploader Metadata\n=================\nName:  ${name || 'Anonymous'}\nEmail: ${email || 'N/A'}\nDate:  ${new Date().toLocaleString()}\n\n`;
+
+    if (hasReason) {
+      commentsContent += `Re-upload Reason:\n-----------------\n${reuploadReason}\n\n`;
+    }
+
+    if (hasNotes) {
+      commentsContent += `User Notes/Comments:\n--------------------\n${notes}`;
+    }
+  }
+
+  return {
+    folderName: site,
+    password,
+    commentsContent,
+    checkExists: !forceOverwrite,
+    files: [
+      {
+        filename: datasetName,
+        content: dataDictionaryContent,
+        description: `Data dictionary uploaded by ${name} (${email}). Notes: ${notes}`,
+      },
+      ...(datasetDescriptionContent
+        ? [
+            {
+              filename: datasetDescriptionFilename,
+              content: datasetDescriptionContent,
+              description: `Dataset description uploaded by ${name} (${email}).`,
+            },
+          ]
+        : []),
+    ],
+  };
+};


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #418

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Moved GoogleDriveUploadFormState and GoogleDriveUploadPayload to internal_types.ts
- Extracted pure business logic (getTimestampSuffix,createUploadPayload) into centralized utilities to decouple payload generation from the React component lifecycle
- Implemented useGoogleDriveUpload hook to encapsulate complex state transitions, including site fetching, upload orchestration, and collision detection
- Refactored the monolithic GoogleDriveUpload component by extracting its large conditional render block into stateless internal functional components like UploadFormView and OverwriteConfirmView. 
- Integrated the new useGoogleDriveUpload hook and enforced strict prop interfaces to resolve ESLint violations
- Restored inline state documentation within the overwrite confirmation view to maintain the flat architectural preference

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the default [Neurobagel `config.json` or any of the term files](https://github.com/neurobagel/communities/tree/main/configs/Neurobagel), make sure their respective counterparts in [neurobagel/communities](https://github.com/neurobagel/communities) have been updated accordingly.

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Refactor Google Drive upload handling by extracting business logic into a reusable hook and utilities, simplifying the component’s rendering flow while preserving existing upload behavior and collision handling.

Enhancements:
- Refactor the GoogleDriveUpload component into smaller stateless views and a dedicated useGoogleDriveUpload hook to encapsulate upload state and orchestration logic.
- Centralize Google Drive upload payload construction and timestamp suffix generation in shared utility functions, backed by new internal type definitions for form state and payload shape.